### PR TITLE
Handle inbox error

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -489,7 +489,7 @@ func (l *BatchSubmitter) sendTransaction(ctx context.Context, txdata txData, que
 		l.inboxIsEOA = &isEOA
 	}
 
-	// only set GasLimit when inbox is EOA so that later on `EstimateGas` will be called
+	// only set GasLimit when inbox is EOA so that later on `EstimateGas` will be called if inbox is a contract
 	if *l.inboxIsEOA {
 		intrinsicGas, err := core.IntrinsicGas(candidate.TxData, nil, false, true, true, false)
 		if err != nil {

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -23,6 +23,7 @@ import (
 )
 
 var ErrBatcherNotRunning = errors.New("batcher is not running")
+var ErrInboxTransactionFailed = errors.New("inbox transaction failed")
 
 type L1Client interface {
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
@@ -68,7 +69,8 @@ type BatchSubmitter struct {
 	lastStoredBlock eth.BlockID
 	lastL1Tip       eth.L1BlockRef
 
-	state *channelManager
+	state      *channelManager
+	inboxIsEOA *bool
 }
 
 // NewBatchSubmitter initializes the BatchSubmitter driver from a preconfigured DriverSetup
@@ -469,12 +471,33 @@ func (l *BatchSubmitter) sendTransaction(ctx context.Context, txdata txData, que
 		candidate = l.calldataTxCandidate(data)
 	}
 
-	intrinsicGas, err := core.IntrinsicGas(candidate.TxData, nil, false, true, true, false)
-	if err != nil {
-		// we log instead of return an error here because txmgr can do its own gas estimation
-		l.Log.Error("Failed to calculate intrinsic gas", "err", err)
-	} else {
-		candidate.GasLimit = intrinsicGas
+	if *candidate.To != l.RollupConfig.BatchInboxAddress {
+		return fmt.Errorf("candidate.To is not inbox")
+	}
+	if l.inboxIsEOA == nil {
+		var l2Client dial.EthClientInterface
+		l2Client, err = l.EndpointProvider.EthClient(ctx)
+		if err != nil {
+			return fmt.Errorf("EthClient failed:%w", err)
+		}
+		var code []byte
+		code, err = l2Client.CodeAt(ctx, *candidate.To, nil)
+		if err != nil {
+			return fmt.Errorf("CodeAt failed:%w", err)
+		}
+		isEOA := len(code) == 0
+		l.inboxIsEOA = &isEOA
+	}
+
+	// only set GasLimit when inbox is EOA so that later on `EstimateGas` will be called
+	if *l.inboxIsEOA {
+		intrinsicGas, err := core.IntrinsicGas(candidate.TxData, nil, false, true, true, false)
+		if err != nil {
+			// we log instead of return an error here because txmgr can do its own gas estimation
+			l.Log.Error("Failed to calculate intrinsic gas", "err", err)
+		} else {
+			candidate.GasLimit = intrinsicGas
+		}
 	}
 
 	queue.Send(txdata.ID(), *candidate, receiptsCh)
@@ -510,6 +533,10 @@ func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txID]) {
 	if r.Err != nil {
 		l.recordFailedTx(r.ID, r.Err)
 	} else {
+		if r.Receipt.Status == types.ReceiptStatusFailed {
+			l.recordFailedTx(r.ID, ErrInboxTransactionFailed)
+			return
+		}
 		l.recordConfirmedTx(r.ID, r.Receipt)
 	}
 }

--- a/op-node/rollup/derive/blob_data_source_test.go
+++ b/op-node/rollup/derive/blob_data_source_test.go
@@ -42,7 +42,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	}
 	calldataTx, _ := types.SignNewTx(privateKey, signer, txData)
 	txs := types.Transactions{calldataTx}
-	data, blobHashes := dataAndHashesFromTxs(txs, &config, batcherAddr)
+	data, blobHashes := dataAndHashesFromTxs(txs, &config, batcherAddr, map[common.Hash]bool{calldataTx.Hash(): true})
 	require.Equal(t, 1, len(data))
 	require.Equal(t, 0, len(blobHashes))
 
@@ -57,14 +57,14 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	}
 	blobTx, _ := types.SignNewTx(privateKey, signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, map[common.Hash]bool{blobTx.Hash(): true})
 	require.Equal(t, 1, len(data))
 	require.Equal(t, 1, len(blobHashes))
 	require.Nil(t, data[0].calldata)
 
 	// try again with both the blob & calldata transactions and make sure both are picked up
 	txs = types.Transactions{blobTx, calldataTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, map[common.Hash]bool{blobTx.Hash(): true, calldataTx.Hash(): true})
 	require.Equal(t, 2, len(data))
 	require.Equal(t, 1, len(blobHashes))
 	require.NotNil(t, data[1].calldata)
@@ -72,7 +72,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	// make sure blob tx to the batch inbox is ignored if not signed by the batcher
 	blobTx, _ = types.SignNewTx(testutils.RandomKey(), signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, map[common.Hash]bool{blobTx.Hash(): true})
 	require.Equal(t, 0, len(data))
 	require.Equal(t, 0, len(blobHashes))
 
@@ -81,7 +81,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	blobTxData.To = testutils.RandomAddress(rng)
 	blobTx, _ = types.SignNewTx(privateKey, signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, map[common.Hash]bool{blobTx.Hash(): true})
 	require.Equal(t, 0, len(data))
 	require.Equal(t, 0, len(blobHashes))
 }

--- a/op-service/dial/ethclient_interface.go
+++ b/op-service/dial/ethclient_interface.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -12,7 +11,6 @@ import (
 // It does not describe all of the functions an ethclient.Client has, only the ones used by callers of the L2 Providers
 type EthClientInterface interface {
 	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
-	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
 
 	Close()
 }

--- a/op-service/dial/ethclient_interface.go
+++ b/op-service/dial/ethclient_interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -11,6 +12,7 @@ import (
 // It does not describe all of the functions an ethclient.Client has, only the ones used by callers of the L2 Providers
 type EthClientInterface interface {
 	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
+	CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error)
 
 	Close()
 }


### PR DESCRIPTION
When submiting, as `eth-client` is readily available so we check whether `batchInboxAddr` is `EOA`. If it's `EOA` then nothing is changed. Otherwise the `GasLimit` is unset so later on `estimate_gas` will be called to check for possible error.

When deriving, in theory,  we only need to check receipt status if `batchInboxAddr` is a contract.
But the api provided by `L1Fetcher` is quite limited(no `CodeAt` api) as it's also called by `op-programe`.
It doesn't seem worth it to add another key type to the hint/oracle just to save a call to `FetchReceipts`, and it's only called once every L1 block, so should not impact performance too much in general.