### PR TITLE
add UseInboxContract option

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -298,6 +298,9 @@ type DeployConfig struct {
 	// IsSoulBackedByNative is a flag that indicates if the SoulGasToken is backed by native.
 	// Only effective when UseSoulGasToken is true.
 	IsSoulBackedByNative bool `json:"isSoulBackedByNative"`
+
+	// UseInboxContract is a flag that indicates if the inbox is a contract
+	UseInboxContract bool `json:"use_inbox_contract"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -229,6 +229,7 @@ var Subcommands = cli.Commands{
 			if err != nil {
 				return err
 			}
+			rollupConfig.UseInboxContract = config.UseInboxContract
 			if err := rollupConfig.Check(); err != nil {
 				return fmt.Errorf("generated rollup config does not pass validation: %w", err)
 			}

--- a/op-node/rollup/derive/blob_data_source.go
+++ b/op-node/rollup/derive/blob_data_source.go
@@ -73,6 +73,8 @@ func (ds *BlobDataSource) Next(ctx context.Context) (eth.Data, error) {
 	return data, nil
 }
 
+// getTxSucceedIfUseInboxContract returns nil if !useInboxContract;
+// otherwise it returns a non-nil map which contains all successful tx hashes
 func getTxSucceedIfUseInboxContract(ctx context.Context, useInboxContract bool, fetcher L1Fetcher, hash common.Hash) (txSucceeded map[common.Hash]bool, err error) {
 	if !useInboxContract {
 		return
@@ -84,7 +86,9 @@ func getTxSucceedIfUseInboxContract(ctx context.Context, useInboxContract bool, 
 
 	txSucceeded = make(map[common.Hash]bool)
 	for _, receipt := range receipts {
-		txSucceeded[receipt.TxHash] = receipt.Status == types.ReceiptStatusSuccessful
+		if receipt.Status == types.ReceiptStatusSuccessful {
+			txSucceeded[receipt.TxHash] = true
+		}
 	}
 	return
 }

--- a/op-node/rollup/derive/blob_data_source.go
+++ b/op-node/rollup/derive/blob_data_source.go
@@ -73,6 +73,22 @@ func (ds *BlobDataSource) Next(ctx context.Context) (eth.Data, error) {
 	return data, nil
 }
 
+func getTxSucceedIfUseInboxContract(ctx context.Context, useInboxContract bool, fetcher L1Fetcher, hash common.Hash) (txSucceeded map[common.Hash]bool, err error) {
+	if !useInboxContract {
+		return
+	}
+	_, receipts, err := fetcher.FetchReceipts(ctx, hash)
+	if err != nil {
+		return nil, NewTemporaryError(fmt.Errorf("failed to fetch L1 block info and receipts: %w", err))
+	}
+
+	txSucceeded = make(map[common.Hash]bool)
+	for _, receipt := range receipts {
+		txSucceeded[receipt.TxHash] = receipt.Status == types.ReceiptStatusSuccessful
+	}
+	return
+}
+
 // open fetches and returns the blob or calldata (as appropriate) from all valid batcher
 // transactions in the referenced block. Returns an empty (non-nil) array if no batcher
 // transactions are found. It returns ResetError if it cannot find the referenced block or a
@@ -85,14 +101,9 @@ func (ds *BlobDataSource) open(ctx context.Context) ([]blobOrCalldata, error) {
 		}
 		return nil, NewTemporaryError(fmt.Errorf("failed to open blob data source: %w", err))
 	}
-	_, receipts, err := ds.fetcher.FetchReceipts(ctx, ds.ref.Hash)
+	txSucceeded, err := getTxSucceedIfUseInboxContract(ctx, ds.dsCfg.useInboxContract, ds.fetcher, ds.ref.Hash)
 	if err != nil {
-		return nil, NewTemporaryError(fmt.Errorf("failed to fetch L1 block info and receipts: %w", err))
-	}
-
-	txSucceeded := make(map[common.Hash]bool)
-	for _, receipt := range receipts {
-		txSucceeded[receipt.TxHash] = receipt.Status == types.ReceiptStatusSuccessful
+		return nil, err
 	}
 
 	data, hashes := dataAndHashesFromTxs(txs, &ds.dsCfg, ds.batcherAddr, txSucceeded)
@@ -129,8 +140,9 @@ func dataAndHashesFromTxs(txs types.Transactions, config *DataSourceConfig, batc
 	var hashes []eth.IndexedBlobHash
 	blobIndex := 0 // index of each blob in the block's blob sidecar
 	for _, tx := range txs {
-		// skip any non-batcher transactions or failed transactions
-		if !(isValidBatchTx(tx, config.l1Signer, config.batchInboxAddress, batcherAddr) && txSucceeded[tx.Hash()]) {
+		// skip any non-batcher transactions or failed transactions if useInboxContract
+		// note: txSucceeded will only be nil when !useInboxContract
+		if !(isValidBatchTx(tx, config.l1Signer, config.batchInboxAddress, batcherAddr) && (txSucceeded == nil || txSucceeded[tx.Hash()])) {
 			blobIndex += len(tx.BlobHashes())
 			continue
 		}

--- a/op-node/rollup/derive/calldata_source_test.go
+++ b/op-node/rollup/derive/calldata_source_test.go
@@ -121,7 +121,7 @@ func TestDataFromEVMTransactions(t *testing.T) {
 			}
 		}
 
-		out := DataFromEVMTransactions(DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress, false}, batcherAddr, txs, testlog.Logger(t, log.LevelCrit))
+		out := DataFromEVMTransactions(DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress, false, false}, batcherAddr, txs, testlog.Logger(t, log.LevelCrit), nil)
 		require.ElementsMatch(t, expectedData, out)
 	}
 

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -56,6 +56,7 @@ func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1Fetcher,
 		l1Signer:          cfg.L1Signer(),
 		batchInboxAddress: cfg.BatchInboxAddress,
 		plasmaEnabled:     cfg.PlasmaEnabled(),
+		useInboxContract:  cfg.UseInboxContract,
 	}
 	return &DataSourceFactory{
 		log:           log,
@@ -92,6 +93,7 @@ type DataSourceConfig struct {
 	l1Signer          types.Signer
 	batchInboxAddress common.Address
 	plasmaEnabled     bool
+	useInboxContract  bool
 }
 
 // isValidBatchTx returns true if:

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -143,6 +143,9 @@ type Config struct {
 	LegacyUsePlasma bool `json:"use_plasma,omitempty"`
 
 	L2BlobConfig *L2BlobConfig `json:"l2_blob_config,omitempty"`
+
+	// UseInboxContract is a flag that indicates if the inbox is a contract
+	UseInboxContract bool `json:"use_inbox_contract"`
 }
 
 type L2BlobConfig struct {


### PR DESCRIPTION
This PR adds a `UseInboxContract` field to DeployConfig and RollupConfig so that this feature is only enabled when UseInboxContract is `true`, in order to prepare for becoming a superchain.