### PR TITLE
Add _findExecTraceAncestor() test for attacking the last branch with non-root-claim ancestor 

### DIFF
--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
@@ -1100,7 +1100,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         if (ancestorPos_.depth() == SPLIT_DEPTH + N_BITS) {
             ancestorClaim_ = ancestorClaimRoot;
         } else {
-            ancestorClaim_ = getClaim(ancestorClaimRoot.raw(), _pos, _daItem);
+            ancestorClaim_ = getClaim(ancestorClaimRoot.raw(), Position.wrap(_pos.raw() - 1), _daItem);
         }
     }
 

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
@@ -1100,7 +1100,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         if (ancestorPos_.depth() == SPLIT_DEPTH + N_BITS) {
             ancestorClaim_ = ancestorClaimRoot;
         } else {
-            ancestorClaim_ = getClaim(ancestorClaimRoot.raw(), Position.wrap(_pos.raw() - 1), _daItem);
+            ancestorClaim_ = getClaim(ancestorClaimRoot.raw(), ancestorPos_, _daItem);
         }
     }
 


### PR DESCRIPTION
- Fix a bug of `_findExecTraceAncestor()` for attacking the last branch with non-root-claim ancestor 
- Add missing test for the above function, and pass `forge test --mt test_stepAttackDummyClaim_attack*`