### PR TITLE
fix the unit test of bond

### DIFF
--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
@@ -1984,14 +1984,14 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
 
         // Perform a bonded move.
         Claim claim = _dummyClaim();
-        uint256 firstBond = _getRequiredBond(0);
+        uint256 firstBond = _getRequiredBondV2(0, 0);
         vm.deal(address(reenter), firstBond);
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: firstBond }(disputed, 0, claim);
-        uint256 secondBond = _getRequiredBond(1);
+        gameProxy.attackV2{ value: firstBond }(disputed, 0, claim, 0);
+        uint256 secondBond = _getRequiredBondV2(1, 0);
         vm.deal(address(reenter), secondBond);
         (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: secondBond }(disputed, 1, claim);
+        gameProxy.attackV2{ value: secondBond }(disputed, 1, claim, 0);
         uint256 reenterBond = firstBond + secondBond;
 
         // Warp past the finalization period


### PR DESCRIPTION
forge test --mc FaultDisputeGameN_Test --mt .*[bB]ond.*

```
Ran 7 tests for test/dispute/FaultDisputeGameN.t.sol:FaultDisputeGameN_Test
[PASS] testFuzz_challengeRootL2Block_receivesBond_succeeds(bytes32,bytes32,uint256) (runs: 65, μ: 907156, ~: 907156)
[PASS] test_getRequiredBond_outOfBounds_reverts() (gas: 12465)
[PASS] test_getRequiredBond_succeeds() (gas: 36816)
[PASS] test_move_incorrectBondAmount_reverts() (gas: 33335)
[PASS] test_resolve_bondPayoutsSeveralActors_succeeds() (gas: 1407849)
[PASS] test_resolve_bondPayouts_succeeds() (gas: 1401801)
[PASS] test_resolve_leftmostBondPayout_succeeds() (gas: 1596079)
Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 473.35ms (178.32ms CPU time)
```

forge test --mc FaultDisputeGameN_Test  --mt test_claimCredit_claimAlreadyResolved_reverts

```
Ran 1 test for test/dispute/FaultDisputeGameN.t.sol:FaultDisputeGameN_Test
[PASS] test_claimCredit_claimAlreadyResolved_reverts() (gas: 835658)
Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 327.36ms (874.00µs CPU time)
```