### PR TITLE
fix the unit test of resolve

### DIFF
--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
@@ -367,9 +367,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         Claim _claim,
         uint64 _attackBranch
     )
-        public
-        payable
-        virtual
+        internal
     {
         // For N = 4 (bisec),
         // 1. _attackBranch == 0 (attack)
@@ -1196,8 +1194,9 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         }
     }
 
-    function attackV2(Claim _disputed, uint256 _parentIndex, Claim _claim, uint64 _attackBranch) public payable {
-        moveV2(_disputed, _parentIndex, _claim, _attackBranch);
+    function attackV2(Claim _disputed, uint256 _parentIndex, uint64 _attackBranch, uint256 _daType, bytes memory _claims) public payable {
+        Claim claim = Claim.wrap(LibDA.getClaimsHash(_daType, MAX_ATTACK_BRANCH, _claims));
+        moveV2(_disputed, _parentIndex, claim, _attackBranch);
     }
 
     function step(

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
@@ -841,35 +841,6 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     //     gameProxy.stepV2(4, 0, absolutePrestateData, hex"");
     // }
 
-    /// @dev Tests that successfully step with true attacking claim when there is a true defend claim(claim5) in the
-    /// middle of the dispute game.
-    function test_stepAttackDummyClaim_defendTrueClaimInTheMiddle_succeeds() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-        bytes memory claimData5 = abi.encode(5, 5);
-        Claim claim5 = Claim.wrap(keccak256(claimData5));
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, _dummyClaim());
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-        gameProxy.step(8, true, claimData5, hex"");
-    }
-
     function test_stepAttackDummyClaim_attackBranch0_succeeds() public {
           // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
@@ -1069,38 +1040,6 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 3, preStateItem);
         vm.expectRevert(ValidStep.selector);
         gameProxy.stepV2({_claimIndex: 4, _attackBranch: 3, _stateData: claimData3, _proof: stepProof});
-    }
-
-    /// @dev Tests that step reverts with false attacking claim when there is a true defend claim(claim5) in the middle
-    /// of the dispute game.
-    function test_stepAttackTrueClaim_defendTrueClaimInTheMiddle_reverts() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-        bytes memory claimData5 = abi.encode(5, 5);
-        Claim claim5 = Claim.wrap(keccak256(claimData5));
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, claim5);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData5, hex"", bytes32(0)));
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, postState_);
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-
-        vm.expectRevert(ValidStep.selector);
-        gameProxy.step(8, true, claimData5, hex"");
     }
 
     function test_addLocalKey_AttackBranch0_succeeds() public {
@@ -1361,75 +1300,6 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         assertEq(startingOutputRoot, claim3.raw());
         (, bytes32 disputedOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 3, disputedDataItem);
         assertEq(disputedOutputRoot, ROOT_CLAIM.raw());
-    }
-
-    /// @dev Tests that step reverts with false defending claim when there is a true defend claim(postState_) in the
-    /// middle of the dispute game.
-    function test_stepDefendDummyClaim_defendTrueClaimInTheMiddle_reverts() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-
-        bytes memory claimData7 = abi.encode(5, 5);
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
-
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-
-        bytes memory _dummyClaimData = abi.encode(gasleft(), gasleft());
-        Claim dummyClaim7 = Claim.wrap(keccak256(_dummyClaimData));
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, dummyClaim7);
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-        vm.expectRevert(ValidStep.selector);
-        gameProxy.step(8, false, _dummyClaimData, hex"");
-    }
-
-    /// @dev Tests that step reverts with true defending claim when there is a true defend claim(postState_) in the
-    /// middle of the dispute game.
-    function test_stepDefendTrueClaim_defendTrueClaimInTheMiddle_reverts() public {
-        // Give the test contract some ether
-        vm.deal(address(this), 1000 ether);
-
-        // Make claims all the way down the tree.
-        (,,,, Claim disputed,,) = gameProxy.claimData(0);
-        gameProxy.attack{ value: _getRequiredBond(0) }(disputed, 0, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attack{ value: _getRequiredBond(1) }(disputed, 1, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attack{ value: _getRequiredBond(2) }(disputed, 2, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(3);
-        gameProxy.attack{ value: _getRequiredBond(3) }(disputed, 3, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(4);
-        gameProxy.attack{ value: _getRequiredBond(4) }(disputed, 4, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC));
-
-        bytes memory claimData7 = abi.encode(5, 5);
-        Claim claim7 = Claim.wrap(keccak256(claimData7));
-        Claim postState_ = Claim.wrap(gameImpl.vm().step(claimData7, hex"", bytes32(0)));
-
-        (,,,, disputed,,) = gameProxy.claimData(5);
-        gameProxy.attack{ value: _getRequiredBond(5) }(disputed, 5, postState_);
-        (,,,, disputed,,) = gameProxy.claimData(6);
-        gameProxy.defend{ value: _getRequiredBond(6) }(disputed, 6, _dummyClaim());
-        (,,,, disputed,,) = gameProxy.claimData(7);
-        gameProxy.attack{ value: _getRequiredBond(7) }(disputed, 7, claim7);
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 8, 0);
-
-        vm.expectRevert(ValidStep.selector);
-        gameProxy.step(8, false, claimData7, hex"");
     }
 
     /// @dev Static unit test for the correctness an uncontested root resolution.

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
@@ -2392,7 +2392,6 @@ contract FaultDisputeGameN_LessSplitDepth_Test is FaultDisputeGame_Init {
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, mid, 2);
 
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 3);
 
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
@@ -2403,6 +2402,7 @@ contract FaultDisputeGameN_LessSplitDepth_Test is FaultDisputeGame_Init {
         FaultDisputeGame.StepProof memory stepProof =
             FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
 
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 3, preStateItem);
         gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 3, _stateData: claimData6, _proof: stepProof });
     }
 
@@ -2447,7 +2447,6 @@ contract FaultDisputeGameN_LessSplitDepth_Test is FaultDisputeGame_Init {
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, mid, 2);
 
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 3);
 
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
@@ -2458,6 +2457,7 @@ contract FaultDisputeGameN_LessSplitDepth_Test is FaultDisputeGame_Init {
         FaultDisputeGame.StepProof memory stepProof =
             FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
 
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 3, preStateItem);
         vm.expectRevert(ValidStep.selector);
         gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 3, _stateData: claimData6, _proof: stepProof });
     }
@@ -2499,7 +2499,6 @@ contract FaultDisputeGameN_LessSplitDepth_Test is FaultDisputeGame_Init {
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, mid, 3);
 
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 3);
 
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
@@ -2515,6 +2514,7 @@ contract FaultDisputeGameN_LessSplitDepth_Test is FaultDisputeGame_Init {
 
         FaultDisputeGame.StepProof memory stepProof =
             FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 3, preStateItem);
         gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 3, _stateData: claimData6, _proof: stepProof });
     }
 

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
@@ -952,7 +952,6 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, root, 0);
 
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 1);
 
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
@@ -970,6 +969,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             vmProof: hex""
         });
 
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 1, preStateItem);
         gameProxy.stepV2({_claimIndex: 4, _attackBranch: 1, _stateData: claimData1, _proof: stepProof});
     }
 
@@ -1000,7 +1000,6 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, root, 0);
 
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 2);
 
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
@@ -1018,6 +1017,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             vmProof: hex""
         });
 
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 2, preStateItem);
         gameProxy.stepV2({_claimIndex: 4, _attackBranch: 2, _stateData: claimData2, _proof: stepProof});
     }
 
@@ -1048,7 +1048,6 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, root, 0);
 
-        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 3);
 
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
@@ -1067,6 +1066,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             vmProof: hex""
         });
 
+        gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 3, preStateItem);
         vm.expectRevert(ValidStep.selector);
         gameProxy.stepV2({_claimIndex: 4, _attackBranch: 3, _stateData: claimData3, _proof: stepProof});
     }

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameNTest.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameNTest.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { GameType, Claim, Duration } from "src/dispute/lib/LibUDT.sol";
+import { FaultDisputeGame } from "src/dispute/FaultDisputeGameN.sol";
+import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
+import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
+import { IBigStepper } from "src/dispute/interfaces/IBigStepper.sol";
+
+contract FaultDisputeGameTest is FaultDisputeGame {
+    constructor(
+        GameType _gameType,
+        Claim _absolutePrestate,
+        uint256 _maxGameDepth,
+        uint256 _splitDepth,
+        Duration _clockExtension,
+        Duration _maxClockDuration,
+        IBigStepper _vm,
+        IDelayedWETH _weth,
+        IAnchorStateRegistry _anchorStateRegistry,
+        uint256 _l2ChainId
+    )
+        FaultDisputeGame(
+            _gameType,
+            _absolutePrestate,
+            _maxGameDepth,
+            _splitDepth,
+            _clockExtension,
+            _maxClockDuration,
+            _vm,
+            _weth,
+            _anchorStateRegistry,
+            _l2ChainId
+        )
+    { }
+
+    // For testing convenience and to minimize changes in the testing code, the submission of the "claims" value is
+    // omitted during the attack. In contract testing, the value of "claims" is already known and does not need to be
+    // submitted via calldata or EIP-4844 during the attack.
+    function attackV2(Claim _disputed, uint256 _parentIndex, Claim _claim, uint64 _attackBranch) public payable {
+        moveV2(_disputed, _parentIndex, _claim, _attackBranch);
+    }
+}


### PR DESCRIPTION
forge test --mc FaultDisputeGameN.*

```
Ran 4 tests for test/dispute/FaultDisputeGameN.t.sol:FaultDisputeGameN_LessSplitDepth_Test
[PASS] test_move_clockExtensionCorrectnessOne_succeeds() (gas: 259451)
[PASS] test_stepAttackDummyClaim_attackBranch3WithNonRootclaim_reverts() (gas: 1023897)
[PASS] test_stepAttackDummyClaim_attackBranch3WithNonRootclaim_succeeds() (gas: 1026915)
[PASS] test_stepAttackDummyClaim_attackRightMostBranchWithNonRootclaim_reverts() (gas: 1022529)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 303.05ms (4.38ms CPU time)
2024-08-04T08:18:45.570749Z  INFO run_tests{name="FaultDisputeGameN_Test"}: forge::runner: done. 70/70 successful duration=597.887293ms

Ran 70 tests for test/dispute/FaultDisputeGameN.t.sol:FaultDisputeGameN_Test
[PASS] testFuzz_addLocalData_oob_reverts(uint256) (runs: 66, μ: 697183, ~: 697183)
[PASS] testFuzz_challengeRootL2Block_receivesBond_succeeds(bytes32,bytes32,uint256) (runs: 66, μ: 907111, ~: 907111)
[PASS] testFuzz_challengeRootL2Block_rightBlockNumber_reverts(bytes32,bytes32,uint256) (runs: 66, μ: 488988, ~: 488988)
[PASS] testFuzz_challengeRootL2Block_succeeds(bytes32,bytes32,uint256) (runs: 66, μ: 490102, ~: 490087)
[PASS] testFuzz_constructor_clockExtensionTooLong_reverts(uint64,uint64) (runs: 66, μ: 3630145, ~: 3629886)
[PASS] testFuzz_constructor_invalidSplitDepth_reverts(uint256) (runs: 66, μ: 3628349, ~: 3628336)
[PASS] testFuzz_constructor_maxDepthTooLarge_reverts(uint256) (runs: 66, μ: 3628462, ~: 3628449)
[PASS] testFuzz_initialize_badExtraData_reverts(uint256) (runs: 66, μ: 2322450, ~: 2397935)
[PASS] testFuzz_initialize_cannotProposeGenesis_reverts(uint256) (runs: 66, μ: 149740, ~: 149742)
[PASS] test_addLocalDataGenesisTransition_static_succeeds() (gas: 1374173)
[PASS] test_addLocalDataMiddle_static_succeeds() (gas: 1394944)
[PASS] test_addLocalKey_AttackBranch0_succeeds() (gas: 1065739)
[PASS] test_addLocalKey_AttackBranch1_succeeds() (gas: 1068505)
[PASS] test_addLocalKey_AttackBranch2_succeeds() (gas: 1068472)
[PASS] test_addLocalKey_AttackBranch3_succeeds() (gas: 1068798)
[PASS] test_addLocalKey_AttackRightMidBranch_succeeds() (gas: 1068285)
[PASS] test_addLocalKey_AttackRightMostBranch_succeeds() (gas: 1063976)
[PASS] test_challengeRootL2Block_badHeaderRLPBlockNumberLength_reverts() (gas: 351289)
[PASS] test_challengeRootL2Block_badHeaderRLP_reverts() (gas: 337310)
[PASS] test_challengeRootL2Block_badProof_reverts() (gas: 14567)
[PASS] test_claimCredit_claimAlreadyResolved_reverts() (gas: 835680)
[PASS] test_createdAt_succeeds() (gas: 13322)
[PASS] test_cwiaCalldata_userCannotControlSelector_succeeds() (gas: 24725)
[PASS] test_extraData_succeeds() (gas: 17471)
[PASS] test_gameData_succeeds() (gas: 18546)
[PASS] test_gameType_succeeds() (gas: 11225)
[PASS] test_getRequiredBond_outOfBounds_reverts() (gas: 12443)
[PASS] test_getRequiredBond_succeeds() (gas: 36859)
[PASS] test_initialize_correctData_succeeds() (gas: 32343)
[PASS] test_initialize_onlyOnce_succeeds() (gas: 13146)
[PASS] test_initialize_receivesETH_succeeds() (gas: 348581)
[PASS] test_move_clockCorrectness_succeeds() (gas: 915793)
[PASS] test_move_clockExtensionCorrectnessSplitGrandChild_succeeds() (gas: 259823)
[PASS] test_move_clockTimeExceeded_reverts() (gas: 48804)
[PASS] test_move_correctStatusExecRootForLastAttackBranch_succeeds() (gas: 662122)
[PASS] test_move_correctStatusExecRoot_succeeds() (gas: 681286)
[PASS] test_move_defendRoot_reverts() (gas: 29759)
[PASS] test_move_duplicateClaim_reverts() (gas: 265389)
[PASS] test_move_duplicateClaimsDifferentSubgames_succeeds() (gas: 841864)
[PASS] test_move_gameDepthExceeded_reverts() (gas: 913853)
[PASS] test_move_gameNotInProgress_reverts() (gas: 26270)
[PASS] test_move_incorrectBondAmount_reverts() (gas: 33313)
[PASS] test_move_incorrectDisputedIndex_reverts() (gas: 267284)
[PASS] test_move_incorrectStatusExecRoot_reverts() (gas: 488720)
[PASS] test_move_nonExistentParent_reverts() (gas: 25664)
[PASS] test_move_simpleAttack_succeeds() (gas: 264385)
[PASS] test_resolution_lastSecondDisputes_succeeds() (gas: 973460)
[PASS] test_resolve_bondPayoutsSeveralActors_succeeds() (gas: 1419871)
[PASS] test_resolve_bondPayouts_succeeds() (gas: 1413845)
[PASS] test_resolve_challengeContested_succeeds() (gas: 770895)
[PASS] test_resolve_claimAlreadyResolved_reverts() (gas: 639421)
[PASS] test_resolve_claimAtMaxDepthAlreadyResolved_reverts() (gas: 1011267)
[PASS] test_resolve_invalidStateSameAnchor_succeeds() (gas: 467775)
[PASS] test_resolve_leftmostBondPayout_succeeds() (gas: 1596079)
[PASS] test_resolve_multiPart_succeeds() (gas: 404554138)
[PASS] test_resolve_notInProgress_reverts() (gas: 9832)
[PASS] test_resolve_outOfOrderResolution_reverts() (gas: 478935)
[PASS] test_resolve_rootContested_succeeds() (gas: 456588)
[PASS] test_resolve_rootUncontestedButUnresolved_reverts() (gas: 15914)
[PASS] test_resolve_rootUncontestedClockNotExpired_succeeds() (gas: 21123)
[PASS] test_resolve_rootUncontested_succeeds() (gas: 169843)
[PASS] test_resolve_stepReached_succeeds() (gas: 1341777)
[PASS] test_resolve_teamDeathmatch_succeeds() (gas: 1191045)
[PASS] test_resolve_validNewerStateUpdatesAnchor_succeeds() (gas: 180903)
[PASS] test_resolve_validOlderStateSameAnchor_succeeds() (gas: 152057)
[PASS] test_rootClaim_succeeds() (gas: 11204)
[PASS] test_stepAttackDummyClaim_attackBranch0_succeeds() (gas: 1024804)
[PASS] test_stepAttackDummyClaim_attackBranch1_succeeds() (gas: 1021622)
[PASS] test_stepAttackDummyClaim_attackBranch2_succeeds() (gas: 1021587)
[PASS] test_stepAttackDummyClaim_attackBranch3_succeeds() (gas: 1017913)
Suite result: ok. 70 passed; 0 failed; 0 skipped; finished in 597.89ms (1.70s CPU time)

Ran 2 test suites in 618.76ms (900.94ms CPU time): 74 tests passed, 0 failed, 0 skipped (74 total tests)
```
