### PR TITLE
Adapt `FaultDisputeN_1v1_Actors_Test` for nary=2

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -1416,7 +1416,9 @@ contract Deploy is Deployer {
                 weth: weth,
                 gameType: GameTypes.ALPHABET,
                 absolutePrestate: outputAbsolutePrestate,
-                faultVm: IBigStepper(new AlphabetVM(outputAbsolutePrestate, PreimageOracle(mustGetAddress("PreimageOracle")), 4)),
+                faultVm: IBigStepper(
+                    new AlphabetVM(outputAbsolutePrestate, PreimageOracle(mustGetAddress("PreimageOracle")), 4)
+                ),
                 // The max depth for the alphabet trace is always 3. Add 1 because split depth is fully inclusive.
                 maxGameDepth: cfg.faultGameSplitDepth() + 3 + 1
             })

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -1416,7 +1416,7 @@ contract Deploy is Deployer {
                 weth: weth,
                 gameType: GameTypes.ALPHABET,
                 absolutePrestate: outputAbsolutePrestate,
-                faultVm: IBigStepper(new AlphabetVM(outputAbsolutePrestate, PreimageOracle(mustGetAddress("PreimageOracle")))),
+                faultVm: IBigStepper(new AlphabetVM(outputAbsolutePrestate, PreimageOracle(mustGetAddress("PreimageOracle")), 4)),
                 // The max depth for the alphabet trace is always 3. Add 1 because split depth is fully inclusive.
                 maxGameDepth: cfg.faultGameSplitDepth() + 3 + 1
             })

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
@@ -355,14 +355,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         parent.counteredBy = msg.sender;
     }
 
-    function moveV2(
-        Claim _disputed,
-        uint256 _challengeIndex,
-        Claim _claim,
-        uint64 _attackBranch
-    )
-        internal
-    {
+    function moveV2(Claim _disputed, uint256 _challengeIndex, Claim _claim, uint64 _attackBranch) internal {
         // For N = 4 (bisec),
         // 1. _attackBranch == 0 (attack)
         // 2. _attackBranch == 1 (attack)
@@ -1196,7 +1189,16 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         }
     }
 
-    function attackV2(Claim _disputed, uint256 _parentIndex, uint64 _attackBranch, uint256 _daType, bytes memory _claims) public payable {
+    function attackV2(
+        Claim _disputed,
+        uint256 _parentIndex,
+        uint64 _attackBranch,
+        uint256 _daType,
+        bytes memory _claims
+    )
+        public
+        payable
+    {
         Claim claim = Claim.wrap(LibDA.getClaimsHash(_daType, MAX_ATTACK_BRANCH, _claims));
         moveV2(_disputed, _parentIndex, claim, _attackBranch);
     }

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
@@ -92,10 +92,10 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
     bool internal initialized;
 
     /// @notice Bits of N-ary search
-    uint256 internal immutable N_BITS;
+    uint256 public immutable N_BITS;
 
     /// @notice Bits of N-ary search
-    uint256 internal immutable MAX_ATTACK_BRANCH;
+    uint256 public immutable MAX_ATTACK_BRANCH;
 
     /// @notice Flag for whether or not the L2 block number claim has been invalidated via `challengeRootL2Block`.
     bool public l2BlockNumberChallenged;

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
@@ -1137,7 +1137,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
     {
         Claim ancestorClaimRoot;
         (ancestorClaimRoot, ancestorPos_) = _findTraceAncestorRoot(_pos, _start, _global);
-        ancestorClaim_ = getClaim(ancestorClaimRoot.raw(), _pos, _daItem);
+        ancestorClaim_ = getClaim(ancestorClaimRoot.raw(), ancestorPos_, _daItem);
     }
 
     function _findTraceAncestorRoot(

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
@@ -303,12 +303,9 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
             if (stepPos.indexAtDepth() % (1 << (MAX_GAME_DEPTH - SPLIT_DEPTH)) == 0) {
                 preStateClaim = ABSOLUTE_PRESTATE;
             } else {
-                (preStateClaim, preStatePos) =
-                    _findTraceAncestorV2(
-                        Position.wrap(parentPos.raw() - 1 + _attackBranch),
-                        claimIndex,
-                        false,
-                        _proof.preStateItem);
+                (preStateClaim, preStatePos) = _findTraceAncestorV2(
+                    Position.wrap(parentPos.raw() - 1 + _attackBranch), claimIndex, false, _proof.preStateItem
+                );
             }
             // For all attacks, the poststate is the parent claim.
             postStatePos = Position.wrap(parent.position.raw() + _attackBranch);
@@ -322,10 +319,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
             preStatePos = Position.wrap(parent.position.raw() + _attackBranch - 1);
             preStateClaim = getClaim(parent.claim.raw(), preStatePos, _proof.preStateItem);
             (postStateClaim, postStatePos) =
-                _findExecTraceAncestor(
-                    Position.wrap(parentPos.raw() + _attackBranch),
-                    claimIndex,
-                    _proof.postStateItem);
+                _findExecTraceAncestor(Position.wrap(parentPos.raw() + _attackBranch), claimIndex, _proof.postStateItem);
         }
 
         // INVARIANT: The prestate is always invalid if the passed `_stateData` is not the
@@ -488,10 +482,17 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
     }
 
     /// @inheritdoc IFaultDisputeGame
-    function addLocalData(uint256 _ident, uint256 _execLeafIdx, uint256 _partOffset) external {
-    }
+    function addLocalData(uint256 _ident, uint256 _execLeafIdx, uint256 _partOffset) external { }
 
-    function addLocalData(uint256 _ident, uint256 _execLeafIdx, uint256 _partOffset, LibDA.DAItem memory _daItem) external returns (Hash uuid_, bytes32 value_) {
+    function addLocalData(
+        uint256 _ident,
+        uint256 _execLeafIdx,
+        uint256 _partOffset,
+        LibDA.DAItem memory _daItem
+    )
+        external
+        returns (Hash uuid_, bytes32 value_)
+    {
         // INVARIANT: Local data can only be added if the game is currently in progress.
         if (status != GameStatus.IN_PROGRESS) revert GameNotInProgress();
 
@@ -961,8 +962,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         // If the move is a defense, the disputed output could have been made by either party. In this case, we
         // need to search for the parent output to determine what the expected status byte should be.
         Position disputedLeafPos = Position.wrap(_parentPos.raw() + _attackBranch);
-        (, Position disputedPos) =
-            _findTraceAncestorRoot({ _pos: disputedLeafPos, _start: _parentIdx, _global: true });
+        (, Position disputedPos) = _findTraceAncestorRoot({ _pos: disputedLeafPos, _start: _parentIdx, _global: true });
         uint8 vmStatus = uint8(_rootClaim.raw()[0]);
 
         if ((MAX_ATTACK_BRANCH != _attackBranch) || (disputedPos.depth() / N_BITS) % 2 == (SPLIT_DEPTH / N_BITS) % 2) {
@@ -1070,7 +1070,8 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
             (disputedClaimRoot_, disputedPos_) = (claim.claim, Position.wrap(claim.position.raw() + attackBranch));
         } else {
             (startingClaimRoot_, startingPos_) = (claim.claim, Position.wrap(claim.position.raw() + attackBranch - 1));
-            (disputedClaimRoot_, disputedPos_) = _findTraceAncestorRoot(Position.wrap(outputPos.raw() + attackBranch), claimIdx, true);
+            (disputedClaimRoot_, disputedPos_) =
+                _findTraceAncestorRoot(Position.wrap(outputPos.raw() + attackBranch), claimIdx, true);
         }
     }
 
@@ -1215,8 +1216,23 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         revert NotSupported();
     }
 
-    function getClaim(bytes32 _claimRoot, Position _pos, LibDA.DAItem memory _daItem) internal view returns (Claim claim_) {
-        LibDA.verifyClaimHash(_daItem.daType, _claimRoot, MAX_ATTACK_BRANCH, _pos.raw() % (MAX_ATTACK_BRANCH + 1), _daItem.dataHash, _daItem.proof);
+    function getClaim(
+        bytes32 _claimRoot,
+        Position _pos,
+        LibDA.DAItem memory _daItem
+    )
+        internal
+        view
+        returns (Claim claim_)
+    {
+        LibDA.verifyClaimHash(
+            _daItem.daType,
+            _claimRoot,
+            MAX_ATTACK_BRANCH,
+            _pos.raw() % (MAX_ATTACK_BRANCH + 1),
+            _daItem.dataHash,
+            _daItem.proof
+        );
         claim_ = Claim.wrap(_daItem.dataHash);
     }
 }

--- a/packages/contracts-bedrock/src/dispute/lib/LibDA.sol
+++ b/packages/contracts-bedrock/src/dispute/lib/LibDA.sol
@@ -17,7 +17,7 @@ library LibDA {
     uint256 constant DA_TYPE_CALLDATA = 0;
     uint256 constant DA_TYPE_EIP4844 = 1;
 
-    function getClaimsHash(uint256 daType, uint256 nelemebts, bytes memory data) internal view returns (bytes32 root)  {
+    function getClaimsHash(uint256 daType, uint256 nelemebts, bytes memory data) internal view returns (bytes32 root) {
         if (daType == DA_TYPE_EIP4844) {
             // TODO: may specify which blob?
             // root = blobhash(0);
@@ -31,7 +31,7 @@ library LibDA {
         require(nelemebts > 0, "data must not empty");
 
         while (nelemebts != 1) {
-            for (uint256 i = 0 ; i < nelemebts / 2; i++) {
+            for (uint256 i = 0; i < nelemebts / 2; i++) {
                 bytes32 hash;
                 uint256 roff = i * 32 * 2;
                 uint256 woff = i * 32;
@@ -60,7 +60,17 @@ library LibDA {
         }
     }
 
-    function verifyClaimHash(uint256 daType, bytes32 root, uint256 nelements, uint256 idx, bytes32 claimHash, bytes memory proof) internal pure {
+    function verifyClaimHash(
+        uint256 daType,
+        bytes32 root,
+        uint256 nelements,
+        uint256 idx,
+        bytes32 claimHash,
+        bytes memory proof
+    )
+        internal
+        pure
+    {
         require(daType == 0, "unsupported DA type");
         bytes32 hash = claimHash;
         uint256 proofOff = 0;
@@ -84,4 +94,3 @@ library LibDA {
         require(root == hash, "proof failed");
     }
 }
-

--- a/packages/contracts-bedrock/test/actors/FaultDisputeActorsN.sol
+++ b/packages/contracts-bedrock/test/actors/FaultDisputeActorsN.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.15;
 import { CommonBase } from "forge-std/Base.sol";
 
 import { FaultDisputeGame } from "src/dispute/FaultDisputeGameN.sol";
+import { FaultDisputeGameTest } from "test/dispute/FaultDisputeGameNTest.sol";
 import { IFaultDisputeGame } from "src/dispute/interfaces/IFaultDisputeGame.sol";
 
 import "src/dispute/lib/Types.sol";
@@ -16,7 +17,7 @@ import "src/dispute/lib/LibDA.sol";
 ///         it suggests.
 abstract contract GameSolver is CommonBase {
     /// @notice The `FaultDisputeGame` proxy that the `GameSolver` will be solving.
-    FaultDisputeGame public immutable GAME;
+    FaultDisputeGameTest public immutable GAME;
     /// @notice The split depth of the game
     uint256 internal immutable SPLIT_DEPTH;
     /// @notice The max depth of the game
@@ -66,7 +67,7 @@ abstract contract GameSolver is CommonBase {
     }
 
     constructor(
-        FaultDisputeGame _gameProxy,
+        FaultDisputeGameTest _gameProxy,
         uint256[] memory _l2Outputs,
         uint256[] memory _counterL2Outputs,
         bytes memory _trace,
@@ -109,7 +110,7 @@ contract HonestGameSolver is GameSolver {
     }
 
     constructor(
-        FaultDisputeGame _gameProxy,
+        FaultDisputeGameTest _gameProxy,
         uint256[] memory l2Outputs,
         uint256[] memory counterL2Outputs,
         bytes memory _honestTrace,
@@ -238,7 +239,7 @@ contract HonestGameSolver is GameSolver {
             kind: MoveKind.Attack,
             attackBranch: _attackBranch,
             value: bond,
-            data: abi.encodeCall(FaultDisputeGame.moveV2, (disputed, _challengeIndex, claimAt(_movePos), _attackBranch))
+            data: abi.encodeCall(FaultDisputeGameTest.attackV2, (disputed, _challengeIndex, claimAt(_movePos), _attackBranch))
         });
     }
 
@@ -316,7 +317,7 @@ contract HonestGameSolver is GameSolver {
             kind: MoveKind.Step,
             attackBranch: _attackBranch,
             value: 0,
-            data: abi.encodeCall(FaultDisputeGame.stepV2, (_challengeIndex, _attackBranch, preStateTrace, stepProof))
+            data: abi.encodeCall(FaultDisputeGameTest.stepV2, (_challengeIndex, _attackBranch, preStateTrace, stepProof))
         });
     }
 
@@ -480,10 +481,10 @@ abstract contract DisputeActor {
 ///         that this actor *can* be dishonest if the trace is faulty, but it will always follow
 ///         the rules of the honest actor.
 contract HonestDisputeActor is DisputeActor {
-    FaultDisputeGame public immutable GAME;
+    FaultDisputeGameTest public immutable GAME;
 
     constructor(
-        FaultDisputeGame _gameProxy,
+        FaultDisputeGameTest _gameProxy,
         uint256[] memory _l2Outputs,
         uint256[] memory _counterL2Outputs,
         bytes memory _trace,

--- a/packages/contracts-bedrock/test/actors/FaultDisputeActorsN.sol
+++ b/packages/contracts-bedrock/test/actors/FaultDisputeActorsN.sol
@@ -7,6 +7,7 @@ import { FaultDisputeGame } from "src/dispute/FaultDisputeGameN.sol";
 import { IFaultDisputeGame } from "src/dispute/interfaces/IFaultDisputeGame.sol";
 
 import "src/dispute/lib/Types.sol";
+import "src/dispute/lib/LibDA.sol";
 
 /// @title GameSolver
 /// @notice The `GameSolver` contract is a contract that can produce an array of available
@@ -23,11 +24,17 @@ abstract contract GameSolver is CommonBase {
     /// @notice The maximum L2 block number that the output bisection portion of the position tree
     ///         can handle.
     uint256 internal immutable MAX_L2_BLOCK_NUMBER;
+    /// @notice 1<<Bits-1 of N-ary search
+    uint256 internal immutable MAX_ATTACK_BRANCH;
+    uint256 internal immutable N_BITS;
+    uint64 internal immutable NOOP_ATTACK = type(uint64).max;
 
     /// @notice The L2 outputs that the `GameSolver` will be representing, keyed by L2 block number - 1.
     uint256[] public l2Outputs;
+    uint256[] public counterL2Outputs;
     /// @notice The execution trace that the `GameSolver` will be representing.
     bytes public trace;
+    bytes public counterTrace;
     /// @notice The raw absolute prestate data.
     bytes public absolutePrestateData;
     /// @notice The offset of previously processed claims in the `GAME` contract's `claimData` array.
@@ -40,9 +47,13 @@ abstract contract GameSolver is CommonBase {
     /// @notice The `MoveKind` enum represents a kind of interaction with the `FaultDisputeGame` contract.
     enum MoveKind {
         Attack,
-        Defend,
         Step,
         AddLocalData
+    }
+
+    enum Actor {
+        Self,
+        Counter
     }
 
     /// @notice The `Move` struct represents a move in the game, and contains information
@@ -50,6 +61,7 @@ abstract contract GameSolver is CommonBase {
     ///         to the `FaultDisputeGame` contract by a consumer of this contract.
     struct Move {
         MoveKind kind;
+        uint256 attackBranch;
         bytes data;
         uint256 value;
     }
@@ -57,16 +69,22 @@ abstract contract GameSolver is CommonBase {
     constructor(
         FaultDisputeGame _gameProxy,
         uint256[] memory _l2Outputs,
+        uint256[] memory _counterL2Outputs,
         bytes memory _trace,
+        bytes memory _counterTrace,
         bytes memory _preStateData
     ) {
         GAME = _gameProxy;
         SPLIT_DEPTH = GAME.splitDepth();
         MAX_DEPTH = GAME.maxGameDepth();
         MAX_L2_BLOCK_NUMBER = 2 ** (MAX_DEPTH - SPLIT_DEPTH);
+        N_BITS = GAME.N_BITS();
+        MAX_ATTACK_BRANCH = GAME.MAX_ATTACK_BRANCH();
 
         l2Outputs = _l2Outputs;
+        counterL2Outputs = _counterL2Outputs;
         trace = _trace;
+        counterTrace = _counterTrace;
         absolutePrestateData = _preStateData;
     }
 
@@ -90,15 +108,17 @@ contract HonestGameSolver is GameSolver {
 
     constructor(
         FaultDisputeGame _gameProxy,
-        uint256[] memory _l2Outputs,
-        bytes memory _trace,
+        uint256[] memory l2Outputs,
+        uint256[] memory counterL2Outputs,
+        bytes memory _honestTrace,
+        bytes memory _dishonestTrace,
         bytes memory _preStateData
     )
-        GameSolver(_gameProxy, _l2Outputs, _trace, _preStateData)
+        GameSolver(_gameProxy, l2Outputs, counterL2Outputs, _honestTrace, _dishonestTrace, _preStateData)
     {
         // Mark agreement with the root claim if the local opinion of the root claim is the same as the
         // observed root claim.
-        agreeWithRoot = Claim.unwrap(outputAt(MAX_L2_BLOCK_NUMBER)) == Claim.unwrap(_gameProxy.rootClaim());
+        agreeWithRoot = Claim.unwrap(outputAt(MAX_L2_BLOCK_NUMBER, Actor.Self)) == Claim.unwrap(_gameProxy.rootClaim());
     }
 
     ////////////////////////////////////////////////////////////////
@@ -120,10 +140,10 @@ contract HonestGameSolver is GameSolver {
             IFaultDisputeGame.ClaimData memory observed = getClaimData(i);
 
             // Determine the direction of the next move to be taken.
-            (Direction moveDirection, Position movePos) = determineDirection(observed);
+            (uint64 moveDirection, Position movePos) = determineDirection(observed);
 
             // Continue if there is no move to be taken against the observed claim.
-            if (moveDirection == Direction.Noop) continue;
+            if (moveDirection == NOOP_ATTACK) continue;
 
             if (movePos.depth() <= MAX_DEPTH) {
                 // bisection
@@ -153,52 +173,43 @@ contract HonestGameSolver is GameSolver {
     function determineDirection(IFaultDisputeGame.ClaimData memory _claimData)
         internal
         view
-        returns (Direction direction_, Position movePos_)
+        returns (uint64 direction_, Position movePos_)
     {
         bool rightLevel = isRightLevel(_claimData.position);
-        bool localAgree = Claim.unwrap(claimAt(_claimData.position)) == Claim.unwrap(_claimData.claim);
-        if (_claimData.parentIndex == type(uint32).max) {
-            // If we agree with the parent claim and it is on a level we agree with, ignore it.
-            if (localAgree && rightLevel) {
-                return (Direction.Noop, Position.wrap(0));
+        uint64 numClaims = _claimData.position.raw() == 1 || (_claimData.position.depth() == (SPLIT_DEPTH + N_BITS)) ? 1 : uint64(MAX_ATTACK_BRANCH - 1);
+        Claim[] memory claims = new Claim[](numClaims);
+        Claim[] memory counterClaims = new Claim[](numClaims);
+        claims = subClaimsAt(_claimData.position, Actor.Self);
+        if (_claimData.parentIndex == type(uint32).max || _claimData.position.depth() == SPLIT_DEPTH + N_BITS ) {
+            // If we agree with the output/trace rootClaim and we agree with, ignore it.
+            bool localAgree = claims[0].raw() == _claimData.claim.raw();
+            if (localAgree) {
+                return (NOOP_ATTACK, Position.wrap(0));
             }
 
-            // The parent claim is the root claim. We must attack if we disagree per the game rules.
-            direction_ = Direction.Attack;
-            movePos_ = _claimData.position.move(true);
-        } else {
-            // Never attempt to defend an execution trace subgame root. Only attack if we disagree with it,
-            // otherwise do nothing.
-            // NOTE: This is not correct behavior in the context of the honest actor; The alphabet game has
-            //       a constant status byte, and is not safe from someone being dishonest in output bisection
-            //       and then posting a correct execution trace bisection root claim.
-            if (_claimData.position.depth() == SPLIT_DEPTH + 1 && localAgree) {
-                return (Direction.Noop, Position.wrap(0));
-            }
+            // The parent claim is the output/trace rootClaim. We must attack if we disagree per the game rules.
+            direction_ = 0;
+            movePos_ = _claimData.position.moveN(N_BITS, 0);
+            return (direction_, movePos_);
+        }
 
-            // If the parent claim is not the root claim, first check if the observed claim is on a level that
-            // agrees with the local view of the root claim. If it is, noop. If it is not, perform an attack or
-            // defense depending on the local view of the observed claim.
-            if (rightLevel) {
-                // Never move against a claim on the right level. Even if it's wrong, if it's uncountered, it furthers
-                // our goals.
-                return (Direction.Noop, Position.wrap(0));
-            } else {
-                // Fetch the local opinion of the parent claim.
-                Claim localParent = claimAt(_claimData.position);
-
-                // NOTE: Poison not handled.
-                if (Claim.unwrap(localParent) != Claim.unwrap(_claimData.claim)) {
-                    // If we disagree with the observed claim, we must attack it.
-                    movePos_ = _claimData.position.move(true);
-                    direction_ = Direction.Attack;
-                } else {
-                    // If we agree with the observed claim, we must defend the observed claim.
-                    movePos_ = _claimData.position.move(false);
-                    direction_ = Direction.Defend;
-                }
+        // If the parent claim is not the root claim, first check if the observed claim is on a level that
+        // agrees with the local view of the root claim. If it is, noop. If it is not, perform an attack or
+        // defense depending on the local view of the observed claim.
+        if (rightLevel) {
+            // Never move against a claim on the right level. Even if it's wrong, if it's uncountered, it furthers
+            // our goals.
+            return (NOOP_ATTACK, Position.wrap(0));
+        }
+        counterClaims = subClaimsAt(_claimData.position, Actor.Counter);
+        uint64 attackBranch_ = uint64(MAX_ATTACK_BRANCH);
+        for (uint64 i = 0; i < uint64(MAX_ATTACK_BRANCH); i++) {
+            if (claims[i].raw() != counterClaims[i].raw()) {
+                attackBranch_ = i;
+                break;
             }
         }
+        return (attackBranch_, _claimData.position.moveN(N_BITS, attackBranch_));
     }
 
     /// @notice Returns a `Move` struct that represents an attack or defense move in the bisection portion
@@ -207,7 +218,7 @@ contract HonestGameSolver is GameSolver {
     /// @dev Note: This function assumes that the `movePos` and `challengeIndex` are valid within the
     ///            output bisection context. This is enforced by the `solveGame` function.
     function handleBisectionMove(
-        Direction _direction,
+        uint64 _attackBranch,
         Position _movePos,
         uint256 _challengeIndex
     )
@@ -215,15 +226,14 @@ contract HonestGameSolver is GameSolver {
         view
         returns (Move memory move_)
     {
-        bool isAttack = _direction == Direction.Attack;
-
         uint256 bond = GAME.getRequiredBond(_movePos);
         (,,,, Claim disputed,,) = GAME.claimData(_challengeIndex);
 
         move_ = Move({
-            kind: isAttack ? MoveKind.Attack : MoveKind.Defend,
+            kind: MoveKind.Attack,
+            attackBranch: _attackBranch,
             value: bond,
-            data: abi.encodeCall(FaultDisputeGame.move, (disputed, _challengeIndex, claimAt(_movePos), isAttack))
+            data: abi.encodeCall(FaultDisputeGame.moveV2, (disputed, _challengeIndex, claimAt(_movePos), _attackBranch))
         });
     }
 
@@ -232,7 +242,7 @@ contract HonestGameSolver is GameSolver {
     /// @dev Note: This function assumes that the `movePos` and `challengeIndex` are valid within the
     ///            execution trace bisection context. This is enforced by the `solveGame` function.
     function handleStepMove(
-        Direction _direction,
+        uint64 _direction,
         Position _parentPos,
         Position _movePos,
         uint256 _challengeIndex
@@ -241,8 +251,9 @@ contract HonestGameSolver is GameSolver {
         view
         returns (Move memory move_)
     {
-        bool isAttack = _direction == Direction.Attack;
         bytes memory preStateTrace;
+        LibDA.DAItem memory preStateItem;
+        LibDA.DAItem memory postStateItem;
 
         // First, we need to find the pre/post state index depending on whether we
         // are making an attack step or a defense step. If the relative index at depth of the
@@ -250,26 +261,67 @@ contract HonestGameSolver is GameSolver {
         // do nothing.
         if ((_movePos.indexAtDepth() % (2 ** (MAX_DEPTH - SPLIT_DEPTH))) != 0) {
             // Grab the trace up to the prestate's trace index.
-            if (isAttack) {
-                Position leafPos = Position.wrap(Position.unwrap(_parentPos) - 1);
-                preStateTrace = abi.encode(leafPos.traceIndex(MAX_DEPTH), stateAt(leafPos));
-            } else {
-                preStateTrace = abi.encode(_parentPos.traceIndex(MAX_DEPTH), stateAt(_parentPos));
-            }
-        } else {
+            Position leafPos = Position.wrap(Position.unwrap(_parentPos) - 1 + _direction);
+            preStateTrace = abi.encode(leafPos.traceIndex(MAX_DEPTH), stateAt(leafPos, Actor.Counter));
+            preStateItem = daItemAtPos(_parentPos, _direction - 1, Actor.Counter);
+        } else { // Left most branch
             preStateTrace = absolutePrestateData;
+            preStateItem = LibDA.DAItem({
+                daType: LibDA.DA_TYPE_CALLDATA,
+                dataHash: GAME.absolutePrestate().raw(),
+                proof: hex""
+            });
         }
+
+        if (_movePos.indexAtDepth() != (1<< (MAX_DEPTH - SPLIT_DEPTH)) - 1 ) {
+             Claim postStateClaim;
+            if (_direction < MAX_ATTACK_BRANCH) {
+                postStateItem = daItemAtPos(_parentPos, _direction, Actor.Counter);
+            } else {
+                postStateItem = daItemAtPos(_parentPos, _direction, Actor.Self);
+            }
+        } else { // Right most branch
+            postStateItem = LibDA.DAItem({
+                daType: LibDA.DA_TYPE_CALLDATA,
+                dataHash: GAME.rootClaim().raw(),
+                proof: hex""
+            });
+        }
+
+        FaultDisputeGame.StepProof memory stepProof = FaultDisputeGame.StepProof({
+            preStateItem: preStateItem,
+            postStateItem: postStateItem,
+            vmProof: hex""
+        });
 
         move_ = Move({
             kind: MoveKind.Step,
+            attackBranch: _direction,
             value: 0,
-            data: abi.encodeCall(FaultDisputeGame.step, (_challengeIndex, isAttack, preStateTrace, hex""))
+            data: abi.encodeCall(FaultDisputeGame.stepV2, (_challengeIndex, _direction, preStateTrace, stepProof))
         });
     }
 
     ////////////////////////////////////////////////////////////////
     //                          HELPERS                           //
     ////////////////////////////////////////////////////////////////
+
+    function daItemAtPos(Position _parentPos, uint64 branch, Actor actor) internal view returns (LibDA.DAItem memory daItem_) {
+        Position leafPos = Position.wrap(Position.unwrap(_parentPos) + branch);
+        Claim[] memory claims = new Claim[](MAX_ATTACK_BRANCH - 1);
+        for (uint128 i = 0; i < branch; i++) {
+            claims[i] = statehashAt(Position.wrap(Position.unwrap(_parentPos) + i), actor);
+        }
+        for (uint128 i = branch + 1; i < MAX_ATTACK_BRANCH; i++) {
+            claims[i-1] = statehashAt(Position.wrap(Position.unwrap(_parentPos) + i), actor);
+        }
+        Claim claim_ = statehashAt(leafPos, actor);
+        daItem_ = LibDA.DAItem({
+            daType: LibDA.DA_TYPE_CALLDATA,
+            dataHash: claim_.raw(),
+            proof: abi.encodePacked(claims)
+        });
+    }
 
     /// @dev Helper function to get the `ClaimData` struct at a given index in the `GAME` contract's
     ///      `claimData` array.
@@ -295,56 +347,91 @@ contract HonestGameSolver is GameSolver {
         });
     }
 
-    /// @notice Returns the player's claim that commits to a given position, swapping between
+    /// @notice Returns the player's subClaims that commits to a given position, swapping between
     ///         output bisection claims and execution trace bisection claims depending on the depth.
     /// @dev Prefer this function over `outputAt` or `statehashAt` directly.
-    function claimAt(Position _position) internal view returns (Claim claim_) {
-        return _position.depth() > SPLIT_DEPTH ? statehashAt(_position) : outputAt(_position);
+    function subClaimsAt(Position _position, Actor actor) internal view returns (Claim[] memory claims_) {
+        return _position.depth() > SPLIT_DEPTH ? statehashesAt(_position, actor) : outputsAt(_position, actor);
+    }
+
+    function claimAt(Position _position) internal view returns (Claim root_) {
+        Claim[] memory claims_ = _position.depth() > SPLIT_DEPTH ? statehashesAt(_position, Actor.Self) : subClaimsAt(_position, Actor.Self);
+        if (claims_.length == 1) { // It's the trace rootClaim
+            root_ = claims_[0];
+        } else {
+            bytes memory input = abi.encodePacked(claims_); // bytes.concat(claims_[0].raw(), claims_[1].raw(), claims_[2].raw());
+            root_ = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, MAX_ATTACK_BRANCH, input));
+        }
+    }
+
+    function outputAt(Position _position) internal view returns (Claim claim_) {
+        return outputAt(_position.traceIndex(SPLIT_DEPTH) + 1, Actor.Self);
     }
 
     /// @notice Returns the mock output at the given position.
-    function outputAt(Position _position) internal view returns (Claim claim_) {
+    function outputsAt(Position _position, Actor actor) internal view returns (Claim[] memory claims_) {
         // Don't allow for positions that are deeper than the split depth.
         if (_position.depth() > SPLIT_DEPTH) {
             revert("GameSolver: invalid position depth");
         }
-
-        return outputAt(_position.traceIndex(SPLIT_DEPTH) + 1);
+        uint256 traceIndex = _position.traceIndex(SPLIT_DEPTH) + 1;
+        uint8 depth = _position.depth();
+        uint256 numClaims = _position.raw() == 1 ? 1 : MAX_ATTACK_BRANCH;
+        claims_ = new Claim[](numClaims);
+        uint256 offset = 1<< (SPLIT_DEPTH - depth);
+        for (uint256 i = 0; i < numClaims; i++) {
+            claims_[i] = outputAt(traceIndex + i * offset, actor);
+        }
     }
 
     /// @notice Returns the mock output at the given L2 block number.
-    function outputAt(uint256 _l2BlockNumber) internal view returns (Claim claim_) {
-        return Claim.wrap(bytes32(l2Outputs[_l2BlockNumber - 1]));
+    function outputAt(uint256 _l2BlockNumber, Actor actor) internal view returns (Claim claim_) {
+        uint256 output = actor == Actor.Self ? l2Outputs[_l2BlockNumber - 1] : counterL2Outputs[_l2BlockNumber - 1];
+        return Claim.wrap(bytes32(output));
     }
 
     /// @notice Returns the player's claim that commits to a given trace index.
-    function statehashAt(uint256 _traceIndex) internal view returns (Claim claim_) {
+    function statehashAt(uint256 _traceIndex, Actor actor) internal view returns (Claim claim_) {
+        bytes storage _trace = actor == Actor.Self ? trace: counterTrace;
         bytes32 hash =
-            keccak256(abi.encode(_traceIndex >= trace.length ? trace.length - 1 : _traceIndex, stateAt(_traceIndex)));
+            keccak256(abi.encode(_traceIndex >= _trace.length ? _trace.length - 1 : _traceIndex, stateAt(_traceIndex, actor)));
         assembly {
             claim_ := or(and(hash, not(shl(248, 0xFF))), shl(248, 1))
         }
     }
 
-    /// @notice Returns the player's claim that commits to a given trace index.
-    function statehashAt(Position _position) internal view returns (Claim claim_) {
-        return statehashAt(_position.traceIndex(MAX_DEPTH));
+    function statehashAt(Position _position, Actor actor) internal view returns (Claim claim_) {
+        uint256 traceIndex = _position.traceIndex(MAX_DEPTH);
+        claim_ = statehashAt(traceIndex, actor);
+    }
+
+    /// @notice Returns the player's subClaims that commits to a given trace index.
+    function statehashesAt(Position _position, Actor actor) internal view returns (Claim[] memory claims_) {
+        uint256 depth = _position.depth();
+        uint256 numClaims = depth == (SPLIT_DEPTH + N_BITS) ? 1 : MAX_ATTACK_BRANCH;
+        uint256 traceIndex = _position.traceIndex(MAX_DEPTH);
+        claims_ = new Claim[](numClaims);
+        uint256 offset = 1<< (MAX_DEPTH - depth);
+        for (uint256 i=0; i < numClaims; i++) {
+            claims_[i] = statehashAt(traceIndex + i * offset, actor);
+        }
     }
 
     /// @notice Returns the state at the trace index within the player's trace.
-    function stateAt(Position _position) internal view returns (uint256 state_) {
-        return stateAt(_position.traceIndex(MAX_DEPTH));
+    function stateAt(Position _position, Actor actor) internal view returns (uint256 state_) {
+        return stateAt(_position.traceIndex(MAX_DEPTH), actor);
     }
 
     /// @notice Returns the state at the trace index within the player's trace.
-    function stateAt(uint256 _traceIndex) internal view returns (uint256 state_) {
+    function stateAt(uint256 _traceIndex, Actor actor) internal view returns (uint256 state_) {
+        bytes storage trace = actor == Actor.Self ? trace: counterTrace;
         return uint256(uint8(_traceIndex >= trace.length ? trace[trace.length - 1] : trace[_traceIndex]));
     }
 
     /// @notice Returns whether or not the position is on a level which opposes the local opinion of the
     ///         root claim.
     function isRightLevel(Position _position) internal view returns (bool isRightLevel_) {
-        isRightLevel_ = agreeWithRoot == (_position.depth() % 2 == 0);
+        isRightLevel_ = agreeWithRoot == ((_position.depth() / N_BITS) % 2 == 0);
     }
 }
 
@@ -371,11 +458,13 @@ contract HonestDisputeActor is DisputeActor {
     constructor(
         FaultDisputeGame _gameProxy,
         uint256[] memory _l2Outputs,
+        uint256[] memory _counterL2Outputs,
         bytes memory _trace,
+        bytes memory _counterTrace,
         bytes memory _preStateData
     ) {
         GAME = _gameProxy;
-        solver = GameSolver(new HonestGameSolver(_gameProxy, _l2Outputs, _trace, _preStateData));
+        solver = GameSolver(new HonestGameSolver(_gameProxy, _l2Outputs, _counterL2Outputs, _trace, _counterTrace, _preStateData));
     }
 
     /// @inheritdoc DisputeActor
@@ -399,10 +488,16 @@ contract HonestDisputeActor is DisputeActor {
                 assembly {
                     challengeIndex := mload(add(moveData, 0x24))
                 }
+                LibDA.DAItem memory dummyItem = LibDA.DAItem({
+                    daType: LibDA.DA_TYPE_CALLDATA,
+                    dataHash: '00000000000000000000000000000000',
+                    proof: hex""
+                });
                 GAME.addLocalData({
                     _ident: LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER,
                     _execLeafIdx: challengeIndex,
-                    _partOffset: 0
+                    _partOffset: 0,
+                    _daItem: dummyItem
                 });
             }
 

--- a/packages/contracts-bedrock/test/actors/FaultDisputeActorsN.sol
+++ b/packages/contracts-bedrock/test/actors/FaultDisputeActorsN.sol
@@ -239,7 +239,9 @@ contract HonestGameSolver is GameSolver {
             kind: MoveKind.Attack,
             attackBranch: _attackBranch,
             value: bond,
-            data: abi.encodeCall(FaultDisputeGameTest.attackV2, (disputed, _challengeIndex, claimAt(_movePos), _attackBranch))
+            data: abi.encodeCall(
+                FaultDisputeGameTest.attackV2, (disputed, _challengeIndex, claimAt(_movePos), _attackBranch)
+            )
         });
     }
 

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -45,7 +45,9 @@ contract FaultDisputeGame_Init is DisputeGameFactory_Init {
         // Set the extra data for the game creation
         extraData = abi.encode(l2BlockNumber);
 
-        AlphabetVM _vm = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
+        AlphabetVM _vm = new AlphabetVM(
+            absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth()
+        );
 
         // Deploy an implementation of the fault game
         gameImpl = new FaultDisputeGame({
@@ -110,7 +112,9 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
     /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `MAX_GAME_DEPTH` parameter is
     ///      greater  than `LibPosition.MAX_POSITION_BITLEN - 1`.
     function testFuzz_constructor_maxDepthTooLarge_reverts(uint256 _maxGameDepth) public {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
+        AlphabetVM alphabetVM = new AlphabetVM(
+            absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth()
+        );
 
         _maxGameDepth = bound(_maxGameDepth, LibPosition.MAX_POSITION_BITLEN, type(uint256).max - 1);
         vm.expectRevert(MaxDepthTooLarge.selector);
@@ -131,7 +135,9 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
     /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
     ///      parameter is greater than or equal to the `MAX_GAME_DEPTH`
     function testFuzz_constructor_invalidSplitDepth_reverts(uint256 _splitDepth) public {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
+        AlphabetVM alphabetVM = new AlphabetVM(
+            absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth()
+        );
 
         _splitDepth = bound(_splitDepth, 2 ** 3, type(uint256).max);
         vm.expectRevert(InvalidSplitDepth.selector);
@@ -157,7 +163,9 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
     )
         public
     {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
+        AlphabetVM alphabetVM = new AlphabetVM(
+            absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth()
+        );
 
         _maxClockDuration = uint64(bound(_maxClockDuration, 0, type(uint64).max - 1));
         _clockExtension = uint64(bound(_clockExtension, _maxClockDuration + 1, type(uint64).max));

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -45,7 +45,7 @@ contract FaultDisputeGame_Init is DisputeGameFactory_Init {
         // Set the extra data for the game creation
         extraData = abi.encode(l2BlockNumber);
 
-        AlphabetVM _vm = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM _vm = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
 
         // Deploy an implementation of the fault game
         gameImpl = new FaultDisputeGame({
@@ -110,7 +110,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
     /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `MAX_GAME_DEPTH` parameter is
     ///      greater  than `LibPosition.MAX_POSITION_BITLEN - 1`.
     function testFuzz_constructor_maxDepthTooLarge_reverts(uint256 _maxGameDepth) public {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
 
         _maxGameDepth = bound(_maxGameDepth, LibPosition.MAX_POSITION_BITLEN, type(uint256).max - 1);
         vm.expectRevert(MaxDepthTooLarge.selector);
@@ -131,7 +131,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
     /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
     ///      parameter is greater than or equal to the `MAX_GAME_DEPTH`
     function testFuzz_constructor_invalidSplitDepth_reverts(uint256 _splitDepth) public {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
 
         _splitDepth = bound(_splitDepth, 2 ** 3, type(uint256).max);
         vm.expectRevert(InvalidSplitDepth.selector);
@@ -157,7 +157,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
     )
         public
     {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
 
         _maxClockDuration = uint64(bound(_maxClockDuration, 0, type(uint64).max - 1));
         _clockExtension = uint64(bound(_clockExtension, _maxClockDuration + 1, type(uint64).max));

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
@@ -39,7 +39,15 @@ contract FaultDisputeGame_Init is DisputeGameFactory_Init {
 
     event ReceiveETH(uint256 amount);
 
-    function init(Claim rootClaim, Claim absolutePrestate, uint256 l2BlockNumber, uint256 maxGameDepth, uint256 splitDepth) public {
+    function init(
+        Claim rootClaim,
+        Claim absolutePrestate,
+        uint256 l2BlockNumber,
+        uint256 maxGameDepth,
+        uint256 splitDepth
+    )
+        public
+    {
         // Set the time to a realistic date.
         vm.warp(1690906994);
 
@@ -105,7 +113,7 @@ contract FaultDisputeGame_Init is DisputeGameFactory_Init {
         return Claim.wrap(keccak256(abi.encode(gasleft())));
     }
 
-    function generateClaims(uint256 total) public view returns (Claim[] memory) {
+    function generateClaims(uint256 total) public pure returns (Claim[] memory) {
         Claim[] memory newClaims = new Claim[](total);
         for (uint256 i = 0; i < total; i++) {
             bytes memory claimData = abi.encode(i + 1, i + 1);
@@ -130,7 +138,13 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         absolutePrestate = _changeClaimStatus(Claim.wrap(keccak256(absolutePrestateData)), VMStatuses.UNFINISHED);
 
         super.setUp();
-        super.init({ rootClaim: ROOT_CLAIM, absolutePrestate: absolutePrestate, l2BlockNumber: 0x10, maxGameDepth: 2 ** 3,splitDepth: 2 ** 2 });
+        super.init({
+            rootClaim: ROOT_CLAIM,
+            absolutePrestate: absolutePrestate,
+            l2BlockNumber: 0x10,
+            maxGameDepth: 2 ** 3,
+            splitDepth: 2 ** 2
+        });
     }
 
     ////////////////////////////////////////////////////////////////
@@ -140,7 +154,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `MAX_GAME_DEPTH` parameter is
     ///      greater  than `LibPosition.MAX_POSITION_BITLEN - 1`.
     function testFuzz_constructor_maxDepthTooLarge_reverts(uint256 _maxGameDepth) public {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
+        AlphabetVM alphabetVM = new AlphabetVM(
+            absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth()
+        );
 
         _maxGameDepth = bound(_maxGameDepth, LibPosition.MAX_POSITION_BITLEN, type(uint256).max - 1);
         vm.expectRevert(MaxDepthTooLarge.selector);
@@ -161,7 +177,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
     ///      parameter is greater than or equal to the `MAX_GAME_DEPTH`
     function testFuzz_constructor_invalidSplitDepth_reverts(uint256 _splitDepth) public {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
+        AlphabetVM alphabetVM = new AlphabetVM(
+            absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth()
+        );
 
         _splitDepth = bound(_splitDepth, 2 ** 3, type(uint256).max);
         vm.expectRevert(InvalidSplitDepth.selector);
@@ -187,7 +205,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     )
         public
     {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
+        AlphabetVM alphabetVM = new AlphabetVM(
+            absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth()
+        );
 
         _maxClockDuration = uint64(bound(_maxClockDuration, 0, type(uint64).max - 1));
         _clockExtension = uint64(bound(_clockExtension, _maxClockDuration + 1, type(uint64).max));
@@ -825,7 +845,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     //     gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, _dummyClaim(), 0);
 
     //     (,,,, disputed,,) = gameProxy.claimData(2);
-    //     gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
+    //     gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(_dummyClaim(),
+    // VMStatuses.PANIC), 0);
 
     //     (,,,, disputed,,) = gameProxy.claimData(3);
     //     gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, _dummyClaim(), 0);
@@ -877,7 +898,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         Claim claim2 = Claim.wrap(keccak256(claimData2));
         Claim claim3 = Claim.wrap(keccak256(claimData3));
 
-        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(),
+            // claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         // Make claims all the way down the tree.
@@ -888,37 +910,30 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, _dummyClaim(), 0);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, root, 0);
 
         // This variable is not used
-        LibDA.DAItem memory localDataItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: '00000000000000000000000000000000',
-            proof: hex""
-        });
+        LibDA.DAItem memory localDataItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: "00000000000000000000000000000000", proof: hex"" });
         gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 0, localDataItem);
 
         // This variable is not used
-        LibDA.DAItem memory preStateItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: absolutePrestate.raw(),
-            proof: hex""
-        });
+        LibDA.DAItem memory preStateItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: absolutePrestate.raw(), proof: hex"" });
         LibDA.DAItem memory postStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
             dataHash: claim1.raw(),
             proof: abi.encodePacked(claim2, claim3)
         });
-        FaultDisputeGame.StepProof memory stepProof = FaultDisputeGame.StepProof({
-            preStateItem: preStateItem,
-            postStateItem: postStateItem,
-            vmProof: hex""
-        });
+        FaultDisputeGame.StepProof memory stepProof =
+            FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
 
-        gameProxy.stepV2({_claimIndex: 4, _attackBranch: 0, _stateData: absolutePrestateData, _proof: stepProof});
+        gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 0, _stateData: absolutePrestateData, _proof: stepProof });
     }
 
     function test_stepAttackDummyClaim_attackBranch1_succeeds() public {
@@ -932,7 +947,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         Claim claim2 = Claim.wrap(keccak256(claimData2));
         Claim claim3 = Claim.wrap(keccak256(claimData3));
 
-        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(),
+            // claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         // Make claims all the way down the tree.
@@ -943,7 +959,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, _dummyClaim(), 0);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, root, 0);
@@ -960,13 +978,10 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             dataHash: claim2.raw(),
             proof: abi.encodePacked(claim1, claim3)
         });
-        FaultDisputeGame.StepProof memory stepProof = FaultDisputeGame.StepProof({
-            preStateItem: preStateItem,
-            postStateItem: postStateItem,
-            vmProof: hex""
-        });
+        FaultDisputeGame.StepProof memory stepProof =
+            FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
 
-        gameProxy.stepV2({_claimIndex: 4, _attackBranch: 1, _stateData: claimData1, _proof: stepProof});
+        gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 1, _stateData: claimData1, _proof: stepProof });
     }
 
     function test_stepAttackDummyClaim_attackBranch2_succeeds() public {
@@ -980,7 +995,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         Claim claim2 = Claim.wrap(keccak256(claimData2));
         Claim claim3 = Claim.wrap(keccak256(claimData3));
 
-        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(),
+            // claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         // Make claims all the way down the tree.
@@ -991,7 +1007,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, _dummyClaim(), 0);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, root, 0);
@@ -1008,13 +1026,10 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             dataHash: claim3.raw(),
             proof: bytes.concat(keccak256(abi.encode(claim1.raw(), claim2.raw())))
         });
-        FaultDisputeGame.StepProof memory stepProof = FaultDisputeGame.StepProof({
-            preStateItem: preStateItem,
-            postStateItem: postStateItem,
-            vmProof: hex""
-        });
+        FaultDisputeGame.StepProof memory stepProof =
+            FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
 
-        gameProxy.stepV2({_claimIndex: 4, _attackBranch: 2, _stateData: claimData2, _proof: stepProof});
+        gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 2, _stateData: claimData2, _proof: stepProof });
     }
 
     function test_stepAttackDummyClaim_attackBranch3_succeeds() public {
@@ -1028,7 +1043,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         Claim claim2 = Claim.wrap(keccak256(claimData2));
         Claim claim3 = Claim.wrap(keccak256(claimData3));
 
-        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(),
+            // claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         // Make claims all the way down the tree.
@@ -1039,7 +1055,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, _dummyClaim(), 0);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, root, 0);
@@ -1057,14 +1075,11 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             dataHash: _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC).raw(),
             proof: hex""
         });
-        FaultDisputeGame.StepProof memory stepProof = FaultDisputeGame.StepProof({
-            preStateItem: preStateItem,
-            postStateItem: postStateItem,
-            vmProof: hex""
-        });
+        FaultDisputeGame.StepProof memory stepProof =
+            FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
 
         vm.expectRevert(ValidStep.selector);
-        gameProxy.stepV2({_claimIndex: 4, _attackBranch: 3, _stateData: claimData3, _proof: stepProof});
+        gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 3, _stateData: claimData3, _proof: stepProof });
     }
 
     /// @dev Tests that step reverts with false attacking claim when there is a true defend claim(claim5) in the middle
@@ -1110,7 +1125,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         Claim claim2 = Claim.wrap(keccak256(claimData2));
         Claim claim3 = Claim.wrap(keccak256(claimData3));
 
-        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(),
+            // claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         // Make claims all the way down the tree.
@@ -1121,25 +1137,26 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, root, 0);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, _dummyClaim(), 0);
 
         // This variable is not used
-        LibDA.DAItem memory startingDataItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: '00000000000000000000000000000000',
-            proof: hex""
-        });
+        LibDA.DAItem memory startingDataItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: "00000000000000000000000000000000", proof: hex"" });
         LibDA.DAItem memory disputedDataItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
             dataHash: claim1.raw(),
             proof: abi.encodePacked(claim2, claim3)
         });
-        (, bytes32 startingOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 0, startingDataItem);
+        (, bytes32 startingOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 0, startingDataItem);
         assertEq(startingOutputRoot, gameProxy.startingRootHash().raw());
-        (, bytes32 disputedOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 0, disputedDataItem);
+        (, bytes32 disputedOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 0, disputedDataItem);
         assertEq(disputedOutputRoot, claim1.raw());
     }
 
@@ -1154,7 +1171,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         Claim claim2 = Claim.wrap(keccak256(claimData2));
         Claim claim3 = Claim.wrap(keccak256(claimData3));
 
-        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(),
+            // claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         // Make claims all the way down the tree.
@@ -1165,7 +1183,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, root, 0);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 1);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 1
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, _dummyClaim(), 0);
@@ -1181,9 +1201,11 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             dataHash: claim2.raw(),
             proof: abi.encodePacked(claim1, claim3)
         });
-        (, bytes32 startingOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 0, startingDataItem);
+        (, bytes32 startingOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 0, startingDataItem);
         assertEq(startingOutputRoot, claim1.raw());
-        (, bytes32 disputedOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 0, disputedDataItem);
+        (, bytes32 disputedOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 0, disputedDataItem);
         assertEq(disputedOutputRoot, claim2.raw());
     }
 
@@ -1198,7 +1220,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         Claim claim2 = Claim.wrap(keccak256(claimData2));
         Claim claim3 = Claim.wrap(keccak256(claimData3));
 
-        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(),
+            // claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         // Make claims all the way down the tree.
@@ -1209,7 +1232,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, root, 0);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 2);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 2
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, _dummyClaim(), 0);
@@ -1225,9 +1250,11 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             dataHash: claim3.raw(),
             proof: bytes.concat(keccak256(abi.encode(claim1.raw(), claim2.raw())))
         });
-        (, bytes32 startingOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 0, startingDataItem);
+        (, bytes32 startingOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 0, startingDataItem);
         assertEq(startingOutputRoot, claim2.raw());
-        (, bytes32 disputedOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 0, disputedDataItem);
+        (, bytes32 disputedOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 0, disputedDataItem);
         assertEq(disputedOutputRoot, claim3.raw());
     }
 
@@ -1242,7 +1269,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         Claim claim2 = Claim.wrap(keccak256(claimData2));
         Claim claim3 = Claim.wrap(keccak256(claimData3));
 
-        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(),
+            // claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         // Make claims all the way down the tree.
@@ -1253,7 +1281,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, root, 0);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(ROOT_CLAIM, VMStatuses.VALID), 3);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(ROOT_CLAIM, VMStatuses.VALID), 3
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, _dummyClaim(), 0);
@@ -1269,9 +1299,11 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             dataHash: claim1.raw(),
             proof: abi.encodePacked(claim2, claim3)
         });
-        (, bytes32 startingOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 0, startingDataItem);
+        (, bytes32 startingOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 0, startingDataItem);
         assertEq(startingOutputRoot, claim3.raw());
-        (, bytes32 disputedOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 0, disputedDataItem);
+        (, bytes32 disputedOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 0, disputedDataItem);
         assertEq(disputedOutputRoot, claim1.raw());
     }
 
@@ -1286,7 +1318,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         Claim claim2 = Claim.wrap(keccak256(claimData2));
         Claim claim3 = Claim.wrap(keccak256(claimData3));
 
-        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(),
+            // claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         // Make claims all the way down the tree.
@@ -1297,7 +1330,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, root, 2);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(ROOT_CLAIM, VMStatuses.VALID), 3);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(ROOT_CLAIM, VMStatuses.VALID), 3
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, _dummyClaim(), 0);
@@ -1309,9 +1344,11 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             proof: bytes.concat(keccak256(abi.encode(claim1.raw(), claim2.raw())))
         });
         LibDA.DAItem memory disputedDataItem = startingDataItem;
-        (, bytes32 startingOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 3, startingDataItem);
+        (, bytes32 startingOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 3, startingDataItem);
         assertEq(startingOutputRoot, claim3.raw());
-        (, bytes32 disputedOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 3, disputedDataItem);
+        (, bytes32 disputedOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 3, disputedDataItem);
         assertEq(disputedOutputRoot, claim3.raw());
     }
 
@@ -1326,7 +1363,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         Claim claim2 = Claim.wrap(keccak256(claimData2));
         Claim claim3 = Claim.wrap(keccak256(claimData3));
 
-        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claim1, claim2, claim3); // bytes.concat(claim1.raw(), claim2.raw(),
+            // claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         // Make claims all the way down the tree.
@@ -1337,7 +1375,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, root, 3);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(ROOT_CLAIM, VMStatuses.PANIC), 3);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(ROOT_CLAIM, VMStatuses.PANIC), 3
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, _dummyClaim(), 0);
@@ -1348,14 +1388,13 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             dataHash: claim3.raw(),
             proof: bytes.concat(keccak256(abi.encode(claim1.raw(), claim2.raw())))
         });
-        LibDA.DAItem memory disputedDataItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: ROOT_CLAIM.raw(),
-            proof: hex""
-        });
-        (, bytes32 startingOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 3, startingDataItem);
+        LibDA.DAItem memory disputedDataItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: ROOT_CLAIM.raw(), proof: hex"" });
+        (, bytes32 startingOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.STARTING_OUTPUT_ROOT, 4, 3, startingDataItem);
         assertEq(startingOutputRoot, claim3.raw());
-        (, bytes32 disputedOutputRoot) = gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 3, disputedDataItem);
+        (, bytes32 disputedOutputRoot) =
+            gameProxy.addLocalData(LocalPreimageKey.DISPUTED_OUTPUT_ROOT, 4, 3, disputedDataItem);
         assertEq(disputedOutputRoot, ROOT_CLAIM.raw());
     }
 
@@ -1667,7 +1706,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         vm.deal(address(this), bal);
 
         Claim[] memory claims = generateClaims(3);
-        bytes memory input = abi.encodePacked(claims[0], claims[1], claims[2]); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claims[0], claims[1], claims[2]); // bytes.concat(claim1.raw(),
+            // claim2.raw(), claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         uint256 bond = _getRequiredBondV2(0, 0);
@@ -1684,7 +1724,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         bond = _getRequiredBondV2(2, 0);
         totalBonded += bond;
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: bond}(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
+        gameProxy.attackV2{ value: bond }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
 
         bond = _getRequiredBondV2(3, 0);
         totalBonded += bond;
@@ -1692,31 +1732,22 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: bond }(disputed, 3, root, 0);
 
         // This variable is not used
-        LibDA.DAItem memory localDataItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: '00000000000000000000000000000000',
-            proof: hex""
-        });
+        LibDA.DAItem memory localDataItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: "00000000000000000000000000000000", proof: hex"" });
         gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 0, localDataItem);
 
         // This variable is not used
-        LibDA.DAItem memory preStateItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: absolutePrestate.raw(),
-            proof: hex""
-        });
+        LibDA.DAItem memory preStateItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: absolutePrestate.raw(), proof: hex"" });
         LibDA.DAItem memory postStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
             dataHash: claims[0].raw(),
             proof: abi.encodePacked(claims[1], claims[2])
         });
-        FaultDisputeGame.StepProof memory stepProof = FaultDisputeGame.StepProof({
-            preStateItem: preStateItem,
-            postStateItem: postStateItem,
-            vmProof: hex""
-        });
+        FaultDisputeGame.StepProof memory stepProof =
+            FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
 
-        gameProxy.stepV2({_claimIndex: 4, _attackBranch: 0, _stateData: absolutePrestateData, _proof: stepProof});
+        gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 0, _stateData: absolutePrestateData, _proof: stepProof });
 
         // Ensure that the step successfully countered the leaf claim.
         (, address counteredBy,,,,,) = gameProxy.claimData(4);
@@ -1758,7 +1789,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         vm.deal(bob, 1000 ether);
 
         Claim[] memory claims = generateClaims(3);
-        bytes memory input = abi.encodePacked(claims[0], claims[1], claims[2]); // bytes.concat(claim1.raw(), claim2.raw(), claim3.raw());
+        bytes memory input = abi.encodePacked(claims[0], claims[1], claims[2]); // bytes.concat(claim1.raw(),
+            // claim2.raw(), claim3.raw());
         Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input));
 
         uint256 bond = _getRequiredBondV2(0, 0);
@@ -1776,7 +1808,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         bond = _getRequiredBondV2(2, 0);
         thisBonded += bond;
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: bond}(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
+        gameProxy.attackV2{ value: bond }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
 
         bond = _getRequiredBondV2(3, 0);
         bobBonded += bond;
@@ -1785,31 +1817,22 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: bond }(disputed, 3, root, 0);
 
         // This variable is not used
-        LibDA.DAItem memory localDataItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: '00000000000000000000000000000000',
-            proof: hex""
-        });
+        LibDA.DAItem memory localDataItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: "00000000000000000000000000000000", proof: hex"" });
         gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 0, localDataItem);
 
         // This variable is not used
-        LibDA.DAItem memory preStateItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: absolutePrestate.raw(),
-            proof: hex""
-        });
+        LibDA.DAItem memory preStateItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: absolutePrestate.raw(), proof: hex"" });
         LibDA.DAItem memory postStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
             dataHash: claims[0].raw(),
             proof: abi.encodePacked(claims[1], claims[2])
         });
-        FaultDisputeGame.StepProof memory stepProof = FaultDisputeGame.StepProof({
-            preStateItem: preStateItem,
-            postStateItem: postStateItem,
-            vmProof: hex""
-        });
+        FaultDisputeGame.StepProof memory stepProof =
+            FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
 
-        gameProxy.stepV2({_claimIndex: 4, _attackBranch: 0, _stateData: absolutePrestateData, _proof: stepProof});
+        gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 0, _stateData: absolutePrestateData, _proof: stepProof });
 
         (, address counteredBy,,,,,) = gameProxy.claimData(4);
         assertEq(counteredBy, address(this));
@@ -1878,7 +1901,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         uint256 thirdBond = _getRequiredBondV2(3, 0);
         (,,,, disputed,,) = gameProxy.claimData(3);
         vm.prank(alice);
-        gameProxy.attackV2{ value: thirdBond}(disputed, 3, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
+        gameProxy.attackV2{ value: thirdBond }(disputed, 3, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
 
         // Resolve all claims
         vm.warp(block.timestamp + 3 days + 12 hours);
@@ -2297,7 +2320,13 @@ contract FaultDisputeGameN_LessSplitDepth_Test is FaultDisputeGame_Init {
         absolutePrestate = _changeClaimStatus(Claim.wrap(keccak256(absolutePrestateData)), VMStatuses.UNFINISHED);
 
         super.setUp();
-        super.init({ rootClaim: ROOT_CLAIM, absolutePrestate: absolutePrestate, l2BlockNumber: 0x10, maxGameDepth: 2 ** 3, splitDepth: 2 });
+        super.init({
+            rootClaim: ROOT_CLAIM,
+            absolutePrestate: absolutePrestate,
+            l2BlockNumber: 0x10,
+            maxGameDepth: 2 ** 3,
+            splitDepth: 2
+        });
     }
 
     function test_stepAttackDummyClaim_attackBranch3WithNonRootclaim_succeeds() public {
@@ -2460,11 +2489,8 @@ contract FaultDisputeGameN_LessSplitDepth_Test is FaultDisputeGame_Init {
             proof: bytes.concat(keccak256(abi.encode(claim4.raw(), claim5.raw())))
         });
 
-        LibDA.DAItem memory postStateItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: rootClaim.raw(),
-            proof: hex""
-        });
+        LibDA.DAItem memory postStateItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: rootClaim.raw(), proof: hex"" });
 
         FaultDisputeGame.StepProof memory stepProof =
             FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
@@ -2497,8 +2523,8 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
     DisputeActor internal honest;
     /// @dev The dishonest actor
     DisputeActor internal dishonest;
-    uint256 internal immutable _splitDepth = 2 ** 3;
-    uint256 internal immutable _maxGameDepth = 2 ** 4;
+    uint256 internal immutable splitDepth = 2 ** 3;
+    uint256 internal immutable maxGameDepth = 2 ** 4;
 
     function setUp() public override {
         // Setup the `FaultDisputeGame`
@@ -2512,23 +2538,23 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
     ///      execution trace bisection is made by the dishonest actor but is honest, honest actor cannot
     ///      attack it without risk of losing).
     function testFuzz_outputBisection1v1honestRoot_succeeds(uint8 _divergeOutput, uint8 _divergeStep) public {
-        // The honest l2 outputs are from [0, 2**_splitDepth - 1] in this game.
-        uint256 lenOutputs = 1 << _splitDepth;
+        // The honest l2 outputs are from [0, 2**splitDepth - 1] in this game.
+        uint256 lenOutputs = 1 << splitDepth;
         uint256[] memory honestL2Outputs = new uint256[](lenOutputs);
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
-        // of bytes [0, 2**_maxGameDepth].
-        uint256 lenTraces = 1 << _maxGameDepth;
+        // The honest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
+        // of bytes [0, 2**maxGameDepth].
+        uint256 lenTraces = 1 << maxGameDepth;
         bytes memory honestTrace = new bytes(lenTraces);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
         }
 
         uint256 divergeAtOutput = bound(_divergeOutput, 0, lenOutputs - 1);
-        uint256 divergeAtStep = bound(_divergeStep, 0, 1 << (_maxGameDepth - _splitDepth) / 2 - 1);
-        uint256 divergeStepOffset = (divergeAtOutput << (_maxGameDepth - _splitDepth)) + divergeAtStep;
+        uint256 divergeAtStep = bound(_divergeStep, 0, 1 << (maxGameDepth - splitDepth) / 2 - 1);
+        uint256 divergeStepOffset = (divergeAtOutput << (maxGameDepth - splitDepth)) + divergeAtStep;
 
         // The dishonest l2 outputs are from [1, lenOutputs] in this game.
         uint256[] memory dishonestL2Outputs = new uint256[](lenOutputs);
@@ -2557,15 +2583,15 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
 
     /// @notice Static unit test for a 1v1 output bisection dispute.
     function test_static_1v1honestRootGenesisAbsolutePrestate_succeeds() public {
-        // The honest l2 outputs are from [0, 2**_splitDepth - 1] in this game.
-        uint256 lenOutputs = 1 << _splitDepth;
+        // The honest l2 outputs are from [0, 2**splitDepth - 1] in this game.
+        uint256 lenOutputs = 1 << splitDepth;
         uint256[] memory honestL2Outputs = new uint256[](lenOutputs);
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
-        // of bytes [0, 2**_maxGameDepth].
-        uint256 lenTraces = 1 << _maxGameDepth;
+        // The honest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
+        // of bytes [0, 2**maxGameDepth].
+        uint256 lenTraces = 1 << maxGameDepth;
         bytes memory honestTrace = new bytes(lenTraces);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2598,15 +2624,15 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
 
     /// @notice Static unit test for a 1v1 output bisection dispute.
     function test_static_1v1dishonestRootGenesisAbsolutePrestate_succeeds() public {
-        // The honest l2 outputs are from [0, 2**_splitDepth - 1] in this game.
-        uint256 lenOutputs = 1 << _splitDepth;
+        // The honest l2 outputs are from [0, 2**splitDepth - 1] in this game.
+        uint256 lenOutputs = 1 << splitDepth;
         uint256[] memory honestL2Outputs = new uint256[](lenOutputs);
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
-        // of bytes [0, 2**_maxGameDepth].
-        uint256 lenTraces = 1 << _maxGameDepth;
+        // The honest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
+        // of bytes [0, 2**maxGameDepth].
+        uint256 lenTraces = 1 << maxGameDepth;
         bytes memory honestTrace = new bytes(lenTraces);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2639,15 +2665,15 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
 
     /// @notice Static unit test for a 1v1 output bisection dispute.
     function test_static_1v1honestRoot_succeeds() public {
-        // The honest l2 outputs are from [0, 2**_splitDepth - 1] in this game.
-        uint256 lenOutputs = 1 << _splitDepth;
+        // The honest l2 outputs are from [0, 2**splitDepth - 1] in this game.
+        uint256 lenOutputs = 1 << splitDepth;
         uint256[] memory honestL2Outputs = new uint256[](lenOutputs);
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
-        // of bytes [0, 2**_maxGameDepth].
-        uint256 lenTraces = 1 << _maxGameDepth;
+        // The honest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
+        // of bytes [0, 2**maxGameDepth].
+        uint256 lenTraces = 1 << maxGameDepth;
         bytes memory honestTrace = new bytes(lenTraces);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2658,7 +2684,7 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i + 1;
         }
-        // The dishonest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
+        // The dishonest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
         // of all zeros.
         bytes memory dishonestTrace = new bytes(lenTraces);
 
@@ -2676,15 +2702,15 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
 
     /// @notice Static unit test for a 1v1 output bisection dispute.
     function test_static_1v1dishonestRoot_succeeds() public {
-        // The honest l2 outputs are from [0, 2**_splitDepth - 1] in this game.
-        uint256 lenOutputs = 1 << _splitDepth;
+        // The honest l2 outputs are from [0, 2**splitDepth - 1] in this game.
+        uint256 lenOutputs = 1 << splitDepth;
         uint256[] memory honestL2Outputs = new uint256[](lenOutputs);
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
-        // of bytes [0, 2**_maxGameDepth].
-        uint256 lenTraces = 1 << _maxGameDepth;
+        // The honest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
+        // of bytes [0, 2**maxGameDepth].
+        uint256 lenTraces = 1 << maxGameDepth;
         bytes memory honestTrace = new bytes(lenTraces);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2695,7 +2721,7 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
             dishonestL2Outputs[i] = i + 1;
         }
-        // The dishonest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
+        // The dishonest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
         // of all zeros.
         bytes memory dishonestTrace = new bytes(lenTraces);
 
@@ -2712,18 +2738,18 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
     }
 
     /// @notice Static unit test for a 1v1 output bisection dispute.
-    // Test will not pass when (N_BIT=2, _splitDepth=4, _maxDepth=8), due to game isn't deep enough, challenger
+    // Test will not pass when (N_BIT=2, splitDepth=4, _maxDepth=8), due to game isn't deep enough, challenger
     // cann't defend rootClaim of traces.
     function test_static_1v1correctRootHalfWay_succeeds() public {
-        // The honest l2 outputs are from [0, 2**_splitDepth - 1] in this game.
-        uint256 lenOutputs = 1 << _splitDepth;
+        // The honest l2 outputs are from [0, 2**splitDepth - 1] in this game.
+        uint256 lenOutputs = 1 << splitDepth;
         uint256[] memory honestL2Outputs = new uint256[](lenOutputs);
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
-        // of bytes [0, 2**_maxGameDepth].
-        uint256 lenTraces = 1 << _maxGameDepth;
+        // The honest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
+        // of bytes [0, 2**maxGameDepth].
+        uint256 lenTraces = 1 << maxGameDepth;
         bytes memory honestTrace = new bytes(lenTraces);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2738,10 +2764,11 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
-        uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth) / 4;
+        uint256 divergeAtOffset = 1 << (maxGameDepth - splitDepth) / 4;
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
+            dishonestTrace[i] =
+                i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
         }
 
         // Run the actor test
@@ -2758,15 +2785,15 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
 
     /// @notice Static unit test for a 1v1 output bisection dispute.
     function test_static_1v1dishonestRootHalfWay_succeeds() public {
-        // The honest l2 outputs are from [0, 2**_splitDepth - 1] in this game.
-        uint256 lenOutputs = 1 << _splitDepth;
+        // The honest l2 outputs are from [0, 2**splitDepth - 1] in this game.
+        uint256 lenOutputs = 1 << splitDepth;
         uint256[] memory honestL2Outputs = new uint256[](lenOutputs);
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
-        // of bytes [0, 2**_maxGameDepth].
-        uint256 lenTraces = 1 << _maxGameDepth;
+        // The honest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
+        // of bytes [0, 2**maxGameDepth].
+        uint256 lenTraces = 1 << maxGameDepth;
         bytes memory honestTrace = new bytes(lenTraces);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2781,10 +2808,11 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
-        uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth) / 4;
+        uint256 divergeAtOffset = 1 << (maxGameDepth - splitDepth) / 4;
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
+            dishonestTrace[i] =
+                i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
         }
 
         // Run the actor test
@@ -2801,15 +2829,15 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
 
     /// @notice Static unit test for a 1v1 output bisection dispute.
     function test_static_1v1correctAbsolutePrestate_succeeds() public {
-        // The honest l2 outputs are from [0, 2**_splitDepth - 1] in this game.
-        uint256 lenOutputs = 1 << _splitDepth;
+        // The honest l2 outputs are from [0, 2**splitDepth - 1] in this game.
+        uint256 lenOutputs = 1 << splitDepth;
         uint256[] memory honestL2Outputs = new uint256[](lenOutputs);
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
-        // of bytes [0, 2**_maxGameDepth].
-        uint256 lenTraces = 1 << _maxGameDepth;
+        // The honest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
+        // of bytes [0, 2**maxGameDepth].
+        uint256 lenTraces = 1 << maxGameDepth;
         bytes memory honestTrace = new bytes(lenTraces);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2824,7 +2852,6 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
-        uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth);
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
             dishonestTrace[i] = i > divergeAtStep ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
@@ -2844,15 +2871,15 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
 
     /// @notice Static unit test for a 1v1 output bisection dispute.
     function test_static_1v1dishonestAbsolutePrestate_succeeds() public {
-        // The honest l2 outputs are from [0, 2**_splitDepth - 1] in this game.
-        uint256 lenOutputs = 1 << _splitDepth;
+        // The honest l2 outputs are from [0, 2**splitDepth - 1] in this game.
+        uint256 lenOutputs = 1 << splitDepth;
         uint256[] memory honestL2Outputs = new uint256[](lenOutputs);
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
-        // of bytes [0, 2**_maxGameDepth].
-        uint256 lenTraces = 1 << _maxGameDepth;
+        // The honest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
+        // of bytes [0, 2**maxGameDepth].
+        uint256 lenTraces = 1 << maxGameDepth;
         bytes memory honestTrace = new bytes(lenTraces);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2867,7 +2894,6 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
-        uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth);
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
             dishonestTrace[i] = i > divergeAtStep ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
@@ -2887,15 +2913,15 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
 
     /// @notice Static unit test for a 1v1 output bisection dispute.
     function test_static_1v1honestRootFinalInstruction_succeeds() public {
-        // The honest l2 outputs are from [0, 2**_splitDepth - 1] in this game.
-        uint256 lenOutputs = 1 << _splitDepth;
+        // The honest l2 outputs are from [0, 2**splitDepth - 1] in this game.
+        uint256 lenOutputs = 1 << splitDepth;
         uint256[] memory honestL2Outputs = new uint256[](lenOutputs);
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
-        // of bytes [0, 2**_maxGameDepth].
-        uint256 lenTraces = 1 << _maxGameDepth;
+        // The honest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
+        // of bytes [0, 2**maxGameDepth].
+        uint256 lenTraces = 1 << maxGameDepth;
         bytes memory honestTrace = new bytes(lenTraces);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2910,10 +2936,11 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
-        uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth) / 2 - 1;
+        uint256 divergeAtOffset = 1 << (maxGameDepth - splitDepth) / 2 - 1;
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
+            dishonestTrace[i] =
+                i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
         }
 
         // Run the actor test
@@ -2930,15 +2957,15 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
 
     /// @notice Static unit test for a 1v1 output bisection dispute.
     function test_static_1v1dishonestRootFinalInstruction_succeeds() public {
-        // The honest l2 outputs are from [0, 2**_splitDepth - 1] in this game.
-        uint256 lenOutputs = 1 << _splitDepth;
+        // The honest l2 outputs are from [0, 2**splitDepth - 1] in this game.
+        uint256 lenOutputs = 1 << splitDepth;
         uint256[] memory honestL2Outputs = new uint256[](lenOutputs);
         for (uint256 i; i < honestL2Outputs.length; i++) {
             honestL2Outputs[i] = i;
         }
-        // The honest trace covers all block -> block + 1 transitions, and is 2**_maxGameDepth bytes long, consisting
-        // of bytes [0, 2**_maxGameDepth].
-        uint256 lenTraces = 1 << _maxGameDepth;
+        // The honest trace covers all block -> block + 1 transitions, and is 2**maxGameDepth bytes long, consisting
+        // of bytes [0, 2**maxGameDepth].
+        uint256 lenTraces = 1 << maxGameDepth;
         bytes memory honestTrace = new bytes(lenTraces);
         for (uint256 i; i < honestTrace.length; i++) {
             honestTrace[i] = bytes1(uint8(i));
@@ -2953,10 +2980,11 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
-        uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth) / 2 - 1;
+        uint256 divergeAtOffset = 1 << (maxGameDepth - splitDepth) / 2 - 1;
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
+            dishonestTrace[i] =
+                i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
         }
 
         // Run the actor test
@@ -3023,8 +3051,8 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
             rootClaim: rootClaim,
             absolutePrestate: absolutePrestateExec,
             l2BlockNumber: _rootClaim,
-            maxGameDepth: _maxGameDepth,
-            splitDepth: _splitDepth
+            maxGameDepth: maxGameDepth,
+            splitDepth: splitDepth
         });
     }
 

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
@@ -272,8 +272,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
 
         Claim claim = _dummyClaim();
         vm.expectRevert(abi.encodeWithSelector(UnexpectedRootClaim.selector, claim));
-        gameProxy =
-            FaultDisputeGameTest(payable(address(disputeGameFactory.create(GAME_TYPE, claim, abi.encode(_blockNumber)))));
+        gameProxy = FaultDisputeGameTest(
+            payable(address(disputeGameFactory.create(GAME_TYPE, claim, abi.encode(_blockNumber))))
+        );
     }
 
     /// @dev Tests that the proxy receives ETH from the dispute game factory.
@@ -942,7 +943,6 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, root, 0);
 
-
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
             dataHash: claim1.raw(),
@@ -957,7 +957,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
 
         gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 1, preStateItem);
-        gameProxy.stepV2({_claimIndex: 4, _attackBranch: 1, _stateData: claimData1, _proof: stepProof});
+        gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 1, _stateData: claimData1, _proof: stepProof });
     }
 
     function test_stepAttackDummyClaim_attackBranch2_succeeds() public {
@@ -990,7 +990,6 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, root, 0);
 
-
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
             dataHash: claim2.raw(),
@@ -1005,7 +1004,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
 
         gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 2, preStateItem);
-        gameProxy.stepV2({_claimIndex: 4, _attackBranch: 2, _stateData: claimData2, _proof: stepProof});
+        gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 2, _stateData: claimData2, _proof: stepProof });
     }
 
     function test_stepAttackDummyClaim_attackBranch3_succeeds() public {
@@ -1037,7 +1036,6 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, root, 0);
-
 
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
@@ -1465,8 +1463,12 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(0, 0) }(disputed, 0, _dummyClaim(), 0);
         gameProxy.attackV2{ value: _getRequiredBondV2(0, 0) }(disputed, 0, _dummyClaim(), 0);
         (,,,, disputed,,) = gameProxy.claimData(1);
-        gameProxy.attackV2{ value: _getRequiredBondV2(1, uint64(MAX_ATTACK_BRANCH)) }(disputed, 1, _dummyClaim(), uint64(MAX_ATTACK_BRANCH));
-        gameProxy.attackV2{ value: _getRequiredBondV2(1, uint64(MAX_ATTACK_BRANCH)) }(disputed, 1, _dummyClaim(), uint64(MAX_ATTACK_BRANCH));
+        gameProxy.attackV2{ value: _getRequiredBondV2(1, uint64(MAX_ATTACK_BRANCH)) }(
+            disputed, 1, _dummyClaim(), uint64(MAX_ATTACK_BRANCH)
+        );
+        gameProxy.attackV2{ value: _getRequiredBondV2(1, uint64(MAX_ATTACK_BRANCH)) }(
+            disputed, 1, _dummyClaim(), uint64(MAX_ATTACK_BRANCH)
+        );
 
         vm.warp(block.timestamp + 3 days + 12 hours);
 
@@ -1945,11 +1947,8 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         if (_ident <= 5) _ident = 0;
 
         // This variable is not used
-        LibDA.DAItem memory localDataItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: '00000000000000000000000000000000',
-            proof: hex""
-        });
+        LibDA.DAItem memory localDataItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: "00000000000000000000000000000000", proof: hex"" });
         vm.expectRevert(InvalidLocalIdent.selector);
         gameProxy.addLocalData(_ident, 3, 0, localDataItem);
     }
@@ -1960,7 +1959,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
         Claim disputed;
         Claim[] memory claims = generateClaims(3);
-        Claim disputedClaim = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, abi.encodePacked(claims[0], claims[1], claims[2])));
+        Claim disputedClaim = Claim.wrap(
+            LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, abi.encodePacked(claims[0], claims[1], claims[2]))
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(0);
         gameProxy.attackV2{ value: _getRequiredBondV2(0, 0) }(disputed, 0, _dummyClaim(), 0);
@@ -1969,13 +1970,12 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, disputedClaim, 0);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0
+        );
 
-        LibDA.DAItem memory startingDataItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: '00000000000000000000000000000000',
-            proof: hex""
-        });
+        LibDA.DAItem memory startingDataItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: "00000000000000000000000000000000", proof: hex"" });
         LibDA.DAItem memory disputedDataItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
             dataHash: claims[0].raw(),
@@ -2029,7 +2029,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     function test_addLocalDataMiddle_static_succeeds() public {
         IPreimageOracle oracle = IPreimageOracle(address(gameProxy.vm().oracle()));
         Claim[] memory claims = generateClaims(3);
-        Claim root = Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, abi.encodePacked(claims[0], claims[1], claims[2])));
+        Claim root = Claim.wrap(
+            LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, abi.encodePacked(claims[0], claims[1], claims[2]))
+        );
 
         (,,,, Claim disputed,,) = gameProxy.claimData(0);
         gameProxy.attackV2{ value: _getRequiredBondV2(0, 0) }(disputed, 0, root, 0);
@@ -2038,7 +2040,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, root, 0);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 3) }(disputed, 2, _changeClaimStatus(ROOT_CLAIM, VMStatuses.VALID), 3);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 3) }(
+            disputed, 2, _changeClaimStatus(ROOT_CLAIM, VMStatuses.VALID), 3
+        );
 
         LibDA.DAItem memory startingDataItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
@@ -2224,7 +2228,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     }
 
     function test_stepAttackDummyClaim_attackDACalldata_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
 
         bytes memory claimData1 = abi.encode(1, 1);
@@ -2244,19 +2248,20 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
         gameProxy.attackV2{ value: _getRequiredBondV2(1, 0) }(disputed, 1, _dummyClaim(), 0);
 
         (,,,, disputed,,) = gameProxy.claimData(2);
-        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0);
+        gameProxy.attackV2{ value: _getRequiredBondV2(2, 0) }(
+            disputed, 2, _changeClaimStatus(_dummyClaim(), VMStatuses.PANIC), 0
+        );
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         uint256 bond = _getRequiredBondV2(3, 0);
         gameProxy.attackV2{ value: bond }(disputed, 3, 0, LibDA.DA_TYPE_CALLDATA, claims);
         vm.expectRevert(ClaimAlreadyExists.selector);
-        gameProxy.attackV2{ value: bond }(disputed, 3, Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, claims)), 0);
+        gameProxy.attackV2{ value: bond }(
+            disputed, 3, Claim.wrap(LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, claims)), 0
+        );
 
-        LibDA.DAItem memory dummyDataItem = LibDA.DAItem({
-            daType: LibDA.DA_TYPE_CALLDATA,
-            dataHash: _dummyClaim().raw(),
-            proof: hex""
-        });
+        LibDA.DAItem memory dummyDataItem =
+            LibDA.DAItem({ daType: LibDA.DA_TYPE_CALLDATA, dataHash: _dummyClaim().raw(), proof: hex"" });
         gameProxy.addLocalData(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, 4, 2, dummyDataItem);
 
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
@@ -2269,12 +2274,9 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
             dataHash: claim3.raw(),
             proof: bytes.concat(keccak256(abi.encode(claim1.raw(), claim2.raw())))
         });
-        FaultDisputeGame.StepProof memory stepProof = FaultDisputeGame.StepProof({
-            preStateItem: preStateItem,
-            postStateItem: postStateItem,
-            vmProof: hex""
-        });
-        gameProxy.stepV2({_claimIndex: 4, _attackBranch: 2, _stateData: claimData2, _proof: stepProof});
+        FaultDisputeGame.StepProof memory stepProof =
+            FaultDisputeGame.StepProof({ preStateItem: preStateItem, postStateItem: postStateItem, vmProof: hex"" });
+        gameProxy.stepV2({ _claimIndex: 4, _attackBranch: 2, _stateData: claimData2, _proof: stepProof });
     }
 }
 
@@ -2346,7 +2348,6 @@ contract FaultDisputeGameN_LessSplitDepth_Test is FaultDisputeGame_Init {
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, mid, 2);
 
-
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
             dataHash: claim6.raw(),
@@ -2401,7 +2402,6 @@ contract FaultDisputeGameN_LessSplitDepth_Test is FaultDisputeGame_Init {
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, mid, 2);
 
-
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,
             dataHash: claim6.raw(),
@@ -2452,7 +2452,6 @@ contract FaultDisputeGameN_LessSplitDepth_Test is FaultDisputeGame_Init {
 
         (,,,, disputed,,) = gameProxy.claimData(3);
         gameProxy.attackV2{ value: _getRequiredBondV2(3, 0) }(disputed, 3, mid, 3);
-
 
         LibDA.DAItem memory preStateItem = LibDA.DAItem({
             daType: LibDA.DA_TYPE_CALLDATA,

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameN.t.sol
@@ -46,7 +46,7 @@ contract FaultDisputeGame_Init is DisputeGameFactory_Init {
         // Set the extra data for the game creation
         extraData = abi.encode(l2BlockNumber);
 
-        AlphabetVM _vm = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM _vm = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), maxGameDepth - splitDepth);
 
         // Deploy an implementation of the fault game
         gameImpl = new FaultDisputeGame({
@@ -140,7 +140,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `MAX_GAME_DEPTH` parameter is
     ///      greater  than `LibPosition.MAX_POSITION_BITLEN - 1`.
     function testFuzz_constructor_maxDepthTooLarge_reverts(uint256 _maxGameDepth) public {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
 
         _maxGameDepth = bound(_maxGameDepth, LibPosition.MAX_POSITION_BITLEN, type(uint256).max - 1);
         vm.expectRevert(MaxDepthTooLarge.selector);
@@ -161,7 +161,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     /// @dev Tests that the constructor of the `FaultDisputeGame` reverts when the `_splitDepth`
     ///      parameter is greater than or equal to the `MAX_GAME_DEPTH`
     function testFuzz_constructor_invalidSplitDepth_reverts(uint256 _splitDepth) public {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
 
         _splitDepth = bound(_splitDepth, 2 ** 3, type(uint256).max);
         vm.expectRevert(InvalidSplitDepth.selector);
@@ -187,7 +187,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     )
         public
     {
-        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM alphabetVM = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
 
         _maxClockDuration = uint64(bound(_maxClockDuration, 0, type(uint64).max - 1));
         _clockExtension = uint64(bound(_clockExtension, _maxClockDuration + 1, type(uint64).max));
@@ -867,7 +867,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     }
 
     function test_stepAttackDummyClaim_attackBranch0_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
 
         bytes memory claimData1 = abi.encode(1, 1);
@@ -922,7 +922,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     }
 
     function test_stepAttackDummyClaim_attackBranch1_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
 
         bytes memory claimData1 = abi.encode(1, 1);
@@ -970,7 +970,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     }
 
     function test_stepAttackDummyClaim_attackBranch2_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
 
         bytes memory claimData1 = abi.encode(1, 1);
@@ -1018,7 +1018,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     }
 
     function test_stepAttackDummyClaim_attackBranch3_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
 
         bytes memory claimData1 = abi.encode(1, 1);
@@ -1100,7 +1100,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     }
 
     function test_addLocalKey_AttackBranch0_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
 
         bytes memory claimData1 = abi.encode(1, 1);
@@ -1144,7 +1144,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     }
 
     function test_addLocalKey_AttackBranch1_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
 
         bytes memory claimData1 = abi.encode(1, 1);
@@ -1188,7 +1188,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     }
 
     function test_addLocalKey_AttackBranch2_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
 
         bytes memory claimData1 = abi.encode(1, 1);
@@ -1232,7 +1232,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     }
 
     function test_addLocalKey_AttackBranch3_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
 
         bytes memory claimData1 = abi.encode(1, 1);
@@ -1276,7 +1276,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     }
 
     function test_addLocalKey_AttackRightMidBranch_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
 
         bytes memory claimData1 = abi.encode(1, 1);
@@ -1316,7 +1316,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     }
 
     function test_addLocalKey_AttackRightMostBranch_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         vm.deal(address(this), 1000 ether);
 
         bytes memory claimData1 = abi.encode(1, 1);
@@ -1752,7 +1752,7 @@ contract FaultDisputeGameN_Test is FaultDisputeGame_Init {
     /// @dev Static unit test asserting that resolve pays out bonds on step, output bisection, and execution trace
     /// moves with 2 actors and a dishonest root claim.
     function test_resolve_bondPayoutsSeveralActors_succeeds() public {
-          // Give the test contract some ether
+        // Give the test contract some ether
         address bob = address(0xb0b);
         vm.deal(address(this), 1000 ether);
         vm.deal(bob, 1000 ether);
@@ -2532,14 +2532,15 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
 
         // The dishonest l2 outputs are from [1, lenOutputs] in this game.
         uint256[] memory dishonestL2Outputs = new uint256[](lenOutputs);
+        uint256 incorrectOutput = 0x01;
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
-            dishonestL2Outputs[i] = i >= divergeAtOutput ? 0xFF : i;
+            dishonestL2Outputs[i] = i >= divergeAtOutput ? incorrectOutput : i;
         }
         // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
         // of all set bits.
         bytes memory dishonestTrace = new bytes(256);
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = i >= divergeStepOffset ? bytes1(uint8(0xFF)) : bytes1(uint8(i));
+            dishonestTrace[i] = i >= divergeStepOffset ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
         }
 
         // Run the actor test
@@ -2578,8 +2579,9 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
         // of all set bits.
         bytes memory dishonestTrace = new bytes(256);
+        uint8 incorrectOutput = 2;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = bytes1(0xFF);
+            dishonestTrace[i] = bytes1(incorrectOutput);
         }
 
         // Run the actor test
@@ -2618,8 +2620,9 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         // The dishonest trace covers all block -> block + 1 transitions, and is 256 bytes long, consisting
         // of all set bits.
         bytes memory dishonestTrace = new bytes(256);
+        uint8 incorrectOutput = 3;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = bytes1(0xFF);
+            dishonestTrace[i] = bytes1(incorrectOutput);
         }
 
         // Run the actor test
@@ -2729,15 +2732,16 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         // The dishonest l2 outputs are half correct, half incorrect.
         uint256[] memory dishonestL2Outputs = new uint256[](lenOutputs);
         uint256 divergeAtOutput = lenOutputs / 2 - 1;
+        uint256 incorrectOutput = 0x03;
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
-            dishonestL2Outputs[i] = i > divergeAtOutput ? 0xFF : i;
+            dishonestL2Outputs[i] = i > divergeAtOutput ? incorrectOutput : i;
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
         uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth) / 4;
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(0xFF) : bytes1(uint8(i));
+            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
         }
 
         // Run the actor test
@@ -2771,15 +2775,16 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         // The dishonest l2 outputs are half correct, half incorrect.
         uint256[] memory dishonestL2Outputs = new uint256[](lenOutputs);
         uint256 divergeAtOutput = lenOutputs / 2 - 1;
+        uint256 incorrectOutput = 0x02;
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
-            dishonestL2Outputs[i] = i > divergeAtOutput ? 0xFF : i;
+            dishonestL2Outputs[i] = i > divergeAtOutput ? incorrectOutput : i;
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
         uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth) / 4;
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(0xFF) : bytes1(uint8(i));
+            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
         }
 
         // Run the actor test
@@ -2813,15 +2818,16 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         // The dishonest l2 outputs are half correct, half incorrect.
         uint256[] memory dishonestL2Outputs = new uint256[](lenOutputs);
         uint256 divergeAtOutput = lenOutputs / 2 - 1;
+        uint256 incorrectOutput = 0x04;
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
-            dishonestL2Outputs[i] = i > divergeAtOutput ? 0xFF : i;
+            dishonestL2Outputs[i] = i > divergeAtOutput ? incorrectOutput : i;
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
         uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth);
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = i > divergeAtStep ? bytes1(0xFF) : bytes1(uint8(i));
+            dishonestTrace[i] = i > divergeAtStep ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
         }
 
         // Run the actor test
@@ -2855,15 +2861,16 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         // The dishonest l2 outputs are half correct, half incorrect.
         uint256[] memory dishonestL2Outputs = new uint256[](lenOutputs);
         uint256 divergeAtOutput = lenOutputs / 2 - 1;
+        uint256 incorrectOutput = 0x05;
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
-            dishonestL2Outputs[i] = i > divergeAtOutput ? 0xFF : i;
+            dishonestL2Outputs[i] = i > divergeAtOutput ? incorrectOutput : i;
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
         uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth);
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = i > divergeAtStep ? bytes1(0xFF) : bytes1(uint8(i));
+            dishonestTrace[i] = i > divergeAtStep ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
         }
 
         // Run the actor test
@@ -2897,15 +2904,16 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         // The dishonest l2 outputs are half correct, half incorrect.
         uint256[] memory dishonestL2Outputs = new uint256[](lenOutputs);
         uint256 divergeAtOutput = lenOutputs / 2 - 1;
+        uint256 incorrectOutput = 0x06;
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
-            dishonestL2Outputs[i] = i > divergeAtOutput ? 0xFF : i;
+            dishonestL2Outputs[i] = i > divergeAtOutput ? incorrectOutput : i;
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
         uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth) / 2 - 1;
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(0xFF) : bytes1(uint8(i));
+            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
         }
 
         // Run the actor test
@@ -2939,15 +2947,16 @@ contract FaultDisputeN_1v1_Actors_Test is FaultDisputeGame_Init {
         // The dishonest l2 outputs are half correct, half incorrect.
         uint256[] memory dishonestL2Outputs = new uint256[](lenOutputs);
         uint256 divergeAtOutput = lenOutputs / 2 - 1;
+        uint256 incorrectOutput = 0x07;
         for (uint256 i; i < dishonestL2Outputs.length; i++) {
-            dishonestL2Outputs[i] = i > divergeAtOutput ? 0xFF : i;
+            dishonestL2Outputs[i] = i > divergeAtOutput ? incorrectOutput : i;
         }
         // The dishonest trace is half correct, half incorrect.
         bytes memory dishonestTrace = new bytes(lenTraces);
         uint256 divergeAtOffset = 1 << (_maxGameDepth - _splitDepth) / 2 - 1;
         uint256 divergeAtStep = lenTraces / 2 - 1;
         for (uint256 i; i < dishonestTrace.length; i++) {
-            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(0xFF) : bytes1(uint8(i));
+            dishonestTrace[i] = i > (divergeAtStep + divergeAtOffset) ? bytes1(uint8(incorrectOutput)) : bytes1(uint8(i));
         }
 
         // Run the actor test

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameNTest.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameNTest.sol
@@ -40,4 +40,13 @@ contract FaultDisputeGameTest is FaultDisputeGame {
     function attackV2(Claim _disputed, uint256 _parentIndex, Claim _claim, uint64 _attackBranch) public payable {
         moveV2(_disputed, _parentIndex, _claim, _attackBranch);
     }
+
+    function stepV2(
+        uint256 _claimIndex,
+        uint64 _attackBranch,
+        bytes calldata _stateData,
+        StepProof calldata _proof
+    ) public virtual override {
+        super.stepV2(_claimIndex,_attackBranch, _stateData, _proof);
+    }
 }

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameNTest.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameNTest.sol
@@ -46,7 +46,11 @@ contract FaultDisputeGameTest is FaultDisputeGame {
         uint64 _attackBranch,
         bytes calldata _stateData,
         StepProof calldata _proof
-    ) public virtual override {
-        super.stepV2(_claimIndex,_attackBranch, _stateData, _proof);
+    )
+        public
+        virtual
+        override
+    {
+        super.stepV2(_claimIndex, _attackBranch, _stateData, _proof);
     }
 }

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -46,7 +46,7 @@ contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
         // Set the extra data for the game creation
         extraData = abi.encode(l2BlockNumber);
 
-        AlphabetVM _vm = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0));
+        AlphabetVM _vm = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
 
         // Use a 7 day delayed WETH to simulate withdrawals.
         DelayedWETH _weth = new DelayedWETH(7 days);

--- a/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/PermissionedDisputeGame.t.sol
@@ -46,7 +46,9 @@ contract PermissionedDisputeGame_Init is DisputeGameFactory_Init {
         // Set the extra data for the game creation
         extraData = abi.encode(l2BlockNumber);
 
-        AlphabetVM _vm = new AlphabetVM(absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth());
+        AlphabetVM _vm = new AlphabetVM(
+            absolutePrestate, new PreimageOracle(0, 0), gameProxy.maxGameDepth() - gameProxy.splitDepth()
+        );
 
         // Use a 7 day delayed WETH to simulate withdrawals.
         DelayedWETH _weth = new DelayedWETH(7 days);

--- a/packages/contracts-bedrock/test/dispute/lib/LibDA.t.sol
+++ b/packages/contracts-bedrock/test/dispute/lib/LibDA.t.sol
@@ -20,17 +20,32 @@ contract LibDA_Test is Test {
         bytes32 root;
         bytes memory input = "0000000000000000000000000000000010000000000000000000000000000001";
         root = LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 2, input);
-        assertEq(root, keccak256(abi.encode(bytes32("00000000000000000000000000000000"), bytes32("10000000000000000000000000000001"))));
+        assertEq(
+            root,
+            keccak256(
+                abi.encode(bytes32("00000000000000000000000000000000"), bytes32("10000000000000000000000000000001"))
+            )
+        );
     }
 
     function test_calldata_three() public view {
         bytes32 root;
-        bytes memory input = "000000000000000000000000000000001000000000000000000000000000000120000000000000000000000000000002";
+        bytes memory input =
+            "000000000000000000000000000000001000000000000000000000000000000120000000000000000000000000000002";
         root = LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input);
-        assertEq(root, keccak256(abi.encode(
-            keccak256(abi.encode(bytes32("00000000000000000000000000000000"), bytes32("10000000000000000000000000000001"))),
-            bytes32("20000000000000000000000000000002")
-        )));
+        assertEq(
+            root,
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        abi.encode(
+                            bytes32("00000000000000000000000000000000"), bytes32("10000000000000000000000000000001")
+                        )
+                    ),
+                    bytes32("20000000000000000000000000000002")
+                )
+            )
+        );
     }
 
     function test_calldata_three1() public view {
@@ -44,39 +59,82 @@ contract LibDA_Test is Test {
         bytes memory input = abi.encodePacked(claim1, claim2, claim3);
 
         bytes32 root = LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input);
-        assertEq(root, keccak256(abi.encode(
-            keccak256(abi.encode(claim1, claim2)),
-            claim3
-        )));
+        assertEq(root, keccak256(abi.encode(keccak256(abi.encode(claim1, claim2)), claim3)));
     }
 
     function test_calldata_seven() public view {
         bytes32 root;
-        bytes memory input = "00000000000000000000000000000000100000000000000000000000000000012000000000000000000000000000000230000000000000000000000000000003400000000000000000000000000000045000000000000000000000000000000560000000000000000000000000000006";
+        bytes memory input =
+            "00000000000000000000000000000000100000000000000000000000000000012000000000000000000000000000000230000000000000000000000000000003400000000000000000000000000000045000000000000000000000000000000560000000000000000000000000000006";
         root = LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 7, input);
-        assertEq(root,
-            keccak256(abi.encode(
-                keccak256(abi.encode(
-                    keccak256(abi.encode(
-                        bytes32("00000000000000000000000000000000"),
-                        bytes32("10000000000000000000000000000001"))),
-                    keccak256(abi.encode(
-                        bytes32("20000000000000000000000000000002"),
-                        bytes32("30000000000000000000000000000003"))))),
-                keccak256(abi.encode(
-                    keccak256(abi.encode(
-                        bytes32("40000000000000000000000000000004"),
-                        bytes32("50000000000000000000000000000005"))),
-                    bytes32("60000000000000000000000000000006")))
-        )));
+        assertEq(
+            root,
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        abi.encode(
+                            keccak256(
+                                abi.encode(
+                                    bytes32("00000000000000000000000000000000"),
+                                    bytes32("10000000000000000000000000000001")
+                                )
+                            ),
+                            keccak256(
+                                abi.encode(
+                                    bytes32("20000000000000000000000000000002"),
+                                    bytes32("30000000000000000000000000000003")
+                                )
+                            )
+                        )
+                    ),
+                    keccak256(
+                        abi.encode(
+                            keccak256(
+                                abi.encode(
+                                    bytes32("40000000000000000000000000000004"),
+                                    bytes32("50000000000000000000000000000005")
+                                )
+                            ),
+                            bytes32("60000000000000000000000000000006")
+                        )
+                    )
+                )
+            )
+        );
     }
 
     function test_calldata_prove_three() public view {
         bytes32 root;
-        bytes memory input = "000000000000000000000000000000001000000000000000000000000000000120000000000000000000000000000002";
+        bytes memory input =
+            "000000000000000000000000000000001000000000000000000000000000000120000000000000000000000000000002";
         root = LibDA.getClaimsHash(LibDA.DA_TYPE_CALLDATA, 3, input);
-        LibDA.verifyClaimHash(LibDA.DA_TYPE_CALLDATA, root, 3, 0, "00000000000000000000000000000000", "1000000000000000000000000000000120000000000000000000000000000002");
-        LibDA.verifyClaimHash(LibDA.DA_TYPE_CALLDATA, root, 3, 1, "10000000000000000000000000000001", "0000000000000000000000000000000020000000000000000000000000000002");
-        LibDA.verifyClaimHash(LibDA.DA_TYPE_CALLDATA, root, 3, 2, "20000000000000000000000000000002", bytes.concat(keccak256(abi.encode(bytes32("00000000000000000000000000000000"), bytes32("10000000000000000000000000000001")))));
+        LibDA.verifyClaimHash(
+            LibDA.DA_TYPE_CALLDATA,
+            root,
+            3,
+            0,
+            "00000000000000000000000000000000",
+            "1000000000000000000000000000000120000000000000000000000000000002"
+        );
+        LibDA.verifyClaimHash(
+            LibDA.DA_TYPE_CALLDATA,
+            root,
+            3,
+            1,
+            "10000000000000000000000000000001",
+            "0000000000000000000000000000000020000000000000000000000000000002"
+        );
+        LibDA.verifyClaimHash(
+            LibDA.DA_TYPE_CALLDATA,
+            root,
+            3,
+            2,
+            "20000000000000000000000000000002",
+            bytes.concat(
+                keccak256(
+                    abi.encode(bytes32("00000000000000000000000000000000"), bytes32("10000000000000000000000000000001"))
+                )
+            )
+        );
     }
 }

--- a/packages/contracts-bedrock/test/mocks/AlphabetVM.sol
+++ b/packages/contracts-bedrock/test/mocks/AlphabetVM.sol
@@ -11,13 +11,13 @@ import "src/dispute/lib/Types.sol";
 contract AlphabetVM is IBigStepper {
     Claim internal immutable ABSOLUTE_PRESTATE;
     IPreimageOracle public oracle;
-    uint256 internal immutable TRACE_DEPTH;  // MaxGameDepth - SplitDepth
+    uint256 internal immutable TRACE_DEPTH; // MaxGameDepth - SplitDepth
 
     constructor(Claim _absolutePrestate, PreimageOracle _oracle, uint256 _traceDepth) {
         ABSOLUTE_PRESTATE = _absolutePrestate;
         oracle = _oracle;
         // Add TRACE_DEPTH to get the starting trace index offset with `startingL2BlockNumber << TRACE_DEPTH`.
-        TRACE_DEPTH =_traceDepth;
+        TRACE_DEPTH = _traceDepth;
     }
 
     /// @inheritdoc IBigStepper

--- a/packages/contracts-bedrock/test/mocks/AlphabetVM.sol
+++ b/packages/contracts-bedrock/test/mocks/AlphabetVM.sol
@@ -11,10 +11,13 @@ import "src/dispute/lib/Types.sol";
 contract AlphabetVM is IBigStepper {
     Claim internal immutable ABSOLUTE_PRESTATE;
     IPreimageOracle public oracle;
+    uint256 internal immutable TRACE_DEPTH;  // MaxGameDepth - SplitDepth
 
-    constructor(Claim _absolutePrestate, PreimageOracle _oracle) {
+    constructor(Claim _absolutePrestate, PreimageOracle _oracle, uint256 _traceDepth) {
         ABSOLUTE_PRESTATE = _absolutePrestate;
         oracle = _oracle;
+        // Add TRACE_DEPTH to get the starting trace index offset with `startingL2BlockNumber << TRACE_DEPTH`.
+        TRACE_DEPTH =_traceDepth;
     }
 
     /// @inheritdoc IBigStepper
@@ -35,14 +38,17 @@ contract AlphabetVM is IBigStepper {
                 PreimageKeyLib.localizeIdent(LocalPreimageKey.DISPUTED_L2_BLOCK_NUMBER, _localContext), 0
             );
             uint256 startingL2BlockNumber = ((uint256(dat) >> 128) & 0xFFFFFFFF) - 1;
-            traceIndex = startingL2BlockNumber << 4;
+            traceIndex = startingL2BlockNumber << TRACE_DEPTH;
             (uint256 absolutePrestateClaim) = abi.decode(_stateData, (uint256));
             claim = absolutePrestateClaim + traceIndex;
+            // In actor test trace is byte1 type, so here the claim is truncated to uint8.
+            claim = uint256(uint8(claim));
         } else {
             // Otherwise, decode the state data.
             (traceIndex, claim) = abi.decode(_stateData, (uint256, uint256));
             traceIndex++;
             claim++;
+            claim = uint256(uint8(claim));
         }
 
         // STF: n -> n + 1


### PR DESCRIPTION
## Changes
1. rename `moveDirection` to `attackBranch`
2. add `_counterTrace` to solve the DA problem of getting counter's sub claims
3. add DA proof in `_handleStepMove`
4. generalize `AlphabetVM.sol` and `FaultDisputeGame.t.sol` for `SPLIT_DEPTH` and `MAX_GAME_DEPTH`
5. generalize for multi-section fault proof when nary >= 2
6. find a bug in `_findTraceAncestorV2` of `faultDisputeGameN.sol`

## Test
`forge test --mc FaultDisputeN_1v1_Actors_Test  -vvv`