### PR TITLE
The "attack" has been modified to support "da" and the "FaultDisputeGameTest" contract has been added to minimize changes in the testing code

### DIFF
--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol
@@ -367,9 +367,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         Claim _claim,
         uint64 _attackBranch
     )
-        public
-        payable
-        virtual
+        internal
     {
         // For N = 4 (bisec),
         // 1. _attackBranch == 0 (attack)
@@ -1196,8 +1194,9 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, ISemver {
         }
     }
 
-    function attackV2(Claim _disputed, uint256 _parentIndex, Claim _claim, uint64 _attackBranch) public payable {
-        moveV2(_disputed, _parentIndex, _claim, _attackBranch);
+    function attackV2(Claim _disputed, uint256 _parentIndex, uint64 _attackBranch, uint256 _daType, bytes memory _claims) public payable {
+        Claim claim = Claim.wrap(LibDA.getClaimsHash(_daType, MAX_ATTACK_BRANCH, _claims));
+        moveV2(_disputed, _parentIndex, claim, _attackBranch);
     }
 
     function step(

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGameNTest.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGameNTest.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { GameType, Claim, Duration } from "src/dispute/lib/LibUDT.sol";
+import { FaultDisputeGame } from "src/dispute/FaultDisputeGameN.sol";
+import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
+import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
+import { IBigStepper } from "src/dispute/interfaces/IBigStepper.sol";
+
+contract FaultDisputeGameTest is FaultDisputeGame {
+    constructor(
+        GameType _gameType,
+        Claim _absolutePrestate,
+        uint256 _maxGameDepth,
+        uint256 _splitDepth,
+        Duration _clockExtension,
+        Duration _maxClockDuration,
+        IBigStepper _vm,
+        IDelayedWETH _weth,
+        IAnchorStateRegistry _anchorStateRegistry,
+        uint256 _l2ChainId
+    )
+        FaultDisputeGame(
+            _gameType,
+            _absolutePrestate,
+            _maxGameDepth,
+            _splitDepth,
+            _clockExtension,
+            _maxClockDuration,
+            _vm,
+            _weth,
+            _anchorStateRegistry,
+            _l2ChainId
+        )
+    { }
+
+    // For testing convenience and to minimize changes in the testing code, the submission of the "claims" value is
+    // omitted during the attack. In contract testing, the value of "claims" is already known and does not need to be
+    // submitted via calldata or EIP-4844 during the attack.
+    function attackV2(Claim _disputed, uint256 _parentIndex, Claim _claim, uint64 _attackBranch) public payable {
+        moveV2(_disputed, _parentIndex, _claim, _attackBranch);
+    }
+}


### PR DESCRIPTION
forge test --mc FaultDisputeGameN.*

```
Ran 4 tests for test/dispute/FaultDisputeGameN.t.sol:FaultDisputeGameN_LessSplitDepth_Test
[PASS] test_move_clockExtensionCorrectnessOne_succeeds() (gas: 259345)
[PASS] test_stepAttackDummyClaim_attackBranch3WithNonRootclaim_reverts() (gas: 1013034)
[PASS] test_stepAttackDummyClaim_attackBranch3WithNonRootclaim_succeeds() (gas: 1016056)
[PASS] test_stepAttackDummyClaim_attackRightMostBranchWithNonRootclaim_reverts() (gas: 1011670)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 336.90ms (5.69ms CPU time)
2024-08-07T01:52:24.868109Z  INFO run_tests{name="FaultDisputeGameN_Test"}: forge::runner: done. 70/70 successful duration=700.688294ms

Ran 70 tests for test/dispute/FaultDisputeGameN.t.sol:FaultDisputeGameN_Test
[PASS] testFuzz_addLocalData_oob_reverts(uint256) (runs: 66, μ: 697072, ~: 697072)
[PASS] testFuzz_challengeRootL2Block_receivesBond_succeeds(bytes32,bytes32,uint256) (runs: 66, μ: 907150, ~: 907135)
[PASS] testFuzz_challengeRootL2Block_rightBlockNumber_reverts(bytes32,bytes32,uint256) (runs: 66, μ: 489034, ~: 489031)
[PASS] testFuzz_challengeRootL2Block_succeeds(bytes32,bytes32,uint256) (runs: 66, μ: 490153, ~: 490153)
[PASS] testFuzz_constructor_clockExtensionTooLong_reverts(uint64,uint64) (runs: 66, μ: 3629813, ~: 3629925)
[PASS] testFuzz_constructor_invalidSplitDepth_reverts(uint256) (runs: 66, μ: 3627940, ~: 3627923)
[PASS] testFuzz_constructor_maxDepthTooLarge_reverts(uint256) (runs: 66, μ: 3628059, ~: 3628036)
[PASS] testFuzz_initialize_badExtraData_reverts(uint256) (runs: 66, μ: 2682570, ~: 2873075)
[PASS] testFuzz_initialize_cannotProposeGenesis_reverts(uint256) (runs: 66, μ: 149760, ~: 149764)
[PASS] test_addLocalDataGenesisTransition_static_succeeds() (gas: 1374152)
[PASS] test_addLocalDataMiddle_static_succeeds() (gas: 1394923)
[PASS] test_addLocalKey_AttackBranch0_succeeds() (gas: 1065601)
[PASS] test_addLocalKey_AttackBranch1_succeeds() (gas: 1068367)
[PASS] test_addLocalKey_AttackBranch2_succeeds() (gas: 1068334)
[PASS] test_addLocalKey_AttackBranch3_succeeds() (gas: 1068660)
[PASS] test_addLocalKey_AttackRightMidBranch_succeeds() (gas: 1068147)
[PASS] test_addLocalKey_AttackRightMostBranch_succeeds() (gas: 1063838)
[PASS] test_challengeRootL2Block_badHeaderRLPBlockNumberLength_reverts() (gas: 351311)
[PASS] test_challengeRootL2Block_badHeaderRLP_reverts() (gas: 337332)
[PASS] test_challengeRootL2Block_badProof_reverts() (gas: 14567)
[PASS] test_claimCredit_claimAlreadyResolved_reverts() (gas: 835618)
[PASS] test_createdAt_succeeds() (gas: 13344)
[PASS] test_cwiaCalldata_userCannotControlSelector_succeeds() (gas: 24680)
[PASS] test_extraData_succeeds() (gas: 17471)
[PASS] test_gameData_succeeds() (gas: 18568)
[PASS] test_gameType_succeeds() (gas: 11247)
[PASS] test_getRequiredBond_outOfBounds_reverts() (gas: 12487)
[PASS] test_getRequiredBond_succeeds() (gas: 36727)
[PASS] test_initialize_correctData_succeeds() (gas: 32322)
[PASS] test_initialize_onlyOnce_succeeds() (gas: 13168)
[PASS] test_initialize_receivesETH_succeeds() (gas: 348603)
[PASS] test_move_clockCorrectness_succeeds() (gas: 915410)
[PASS] test_move_clockExtensionCorrectnessSplitGrandChild_succeeds() (gas: 259717)
[PASS] test_move_clockTimeExceeded_reverts() (gas: 48762)
[PASS] test_move_correctStatusExecRootForLastAttackBranch_succeeds() (gas: 661996)
[PASS] test_move_correctStatusExecRoot_succeeds() (gas: 681160)
[PASS] test_move_defendRoot_reverts() (gas: 29738)
[PASS] test_move_duplicateClaim_reverts() (gas: 265369)
[PASS] test_move_duplicateClaimsDifferentSubgames_succeeds() (gas: 841760)
[PASS] test_move_gameDepthExceeded_reverts() (gas: 913686)
[PASS] test_move_gameNotInProgress_reverts() (gas: 26249)
[PASS] test_move_incorrectBondAmount_reverts() (gas: 33292)
[PASS] test_move_incorrectDisputedIndex_reverts() (gas: 267243)
[PASS] test_move_incorrectStatusExecRoot_reverts() (gas: 488594)
[PASS] test_move_nonExistentParent_reverts() (gas: 25708)
[PASS] test_move_simpleAttack_succeeds() (gas: 264257)
[PASS] test_resolution_lastSecondDisputes_succeeds() (gas: 973643)
[PASS] test_resolve_bondPayoutsSeveralActors_succeeds() (gas: 1407645)
[PASS] test_resolve_bondPayouts_succeeds() (gas: 1401619)
[PASS] test_resolve_challengeContested_succeeds() (gas: 770832)
[PASS] test_resolve_claimAlreadyResolved_reverts() (gas: 639337)
[PASS] test_resolve_claimAtMaxDepthAlreadyResolved_reverts() (gas: 1010967)
[PASS] test_resolve_invalidStateSameAnchor_succeeds() (gas: 467843)
[PASS] test_resolve_leftmostBondPayout_succeeds() (gas: 1595952)
[PASS] test_resolve_multiPart_succeeds() (gas: 404511065)
[PASS] test_resolve_notInProgress_reverts() (gas: 9832)
[PASS] test_resolve_outOfOrderResolution_reverts() (gas: 478851)
[PASS] test_resolve_rootContested_succeeds() (gas: 456590)
[PASS] test_resolve_rootUncontestedButUnresolved_reverts() (gas: 15914)
[PASS] test_resolve_rootUncontestedClockNotExpired_succeeds() (gas: 21123)
[PASS] test_resolve_rootUncontested_succeeds() (gas: 169864)
[PASS] test_resolve_stepReached_succeeds() (gas: 1341519)
[PASS] test_resolve_teamDeathmatch_succeeds() (gas: 1191007)
[PASS] test_resolve_validNewerStateUpdatesAnchor_succeeds() (gas: 180967)
[PASS] test_resolve_validOlderStateSameAnchor_succeeds() (gas: 152123)
[PASS] test_rootClaim_succeeds() (gas: 11159)
[PASS] test_stepAttackDummyClaim_attackBranch0_succeeds() (gas: 1012622)
[PASS] test_stepAttackDummyClaim_attackBranch1_succeeds() (gas: 1008990)
[PASS] test_stepAttackDummyClaim_attackBranch2_succeeds() (gas: 1008955)
[PASS] test_stepAttackDummyClaim_attackBranch3_succeeds() (gas: 1007051)
Suite result: ok. 70 passed; 0 failed; 0 skipped; finished in 700.69ms (1.87s CPU time)

Ran 2 test suites in 722.62ms (1.04s CPU time): 74 tests passed, 0 failed, 0 skipped (74 total tests)
```