### PR TITLE
Move DACConfig away from rollup.Config

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -292,7 +292,6 @@ type DeployConfig struct {
 	// L2GenesisBlobTimeOffset is the number of seconds after genesis block that the L2Blob hard fork activates.
 	// Set it to 0 to activate at genesis. Nil to disable L2Blob.
 	L2GenesisBlobTimeOffset *hexutil.Uint64 `json:"l2GenesisBlobTimeOffset,omitempty"`
-	DACURLS                 []string        `json:"dac_urls,omitempty"`
 
 	// UseSoulGasToken is a flag that indicates if the system is using SoulGasToken
 	UseSoulGasToken bool `json:"useSoulGasToken"`
@@ -646,9 +645,6 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *types.Block, l2GenesisBlockHas
 	if d.L2GenesisBlobTimeOffset != nil {
 		l2BlobConfig = &rollup.L2BlobConfig{
 			L2BlobTime: d.L2BlobTime(l1StartBlock.Time()),
-		}
-		if len(d.DACURLS) > 0 {
-			l2BlobConfig.DACConfig = &rollup.DACConfig{URLS: d.DACURLS}
 		}
 	}
 	return &rollup.Config{

--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -65,7 +65,7 @@ type safeDB interface {
 
 func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, blobsSrc derive.L1BlobsFetcher, plasmaSrc derive.PlasmaInputFetcher, eng L2API, cfg *rollup.Config, syncCfg *sync.Config, safeHeadListener safeDB) *L2Verifier {
 	metrics := &testutils.TestDerivationMetrics{}
-	engine := derive.NewEngineController(eng, log, metrics, cfg, syncCfg.SyncMode)
+	engine := derive.NewEngineController(eng, log, metrics, cfg, syncCfg.SyncMode, nil)
 	pipeline := derive.NewDerivationPipeline(log, cfg, l1, blobsSrc, plasmaSrc, eng, engine, metrics, syncCfg, safeHeadListener)
 	pipeline.Reset()
 

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -353,6 +353,12 @@ var (
 		Value:    time.Second * 1,
 		Category: SequencerCategory,
 	}
+	DACUrlsFlag = &cli.StringFlag{
+		Name:     "dac.urls",
+		Usage:    "dac urls for sequencer when l2 blob is enabled",
+		EnvVars:  prefixEnvVars("DAC_URLS"),
+		Category: SequencerCategory,
+	}
 )
 
 var requiredFlags = []cli.Flag{

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -402,7 +402,8 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Logger
 	} else {
 		n.safeDB = safedb.Disabled
 	}
-	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n.beacon, n, n, n.log, snapshotLog, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, plasmaDA)
+	dacClient := cfg.DACConfig.Client()
+	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n.beacon, n, n, n.log, snapshotLog, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, plasmaDA, dacClient)
 	return nil
 }
 

--- a/op-node/rollup/derive/engine_controller.go
+++ b/op-node/rollup/derive/engine_controller.go
@@ -44,6 +44,10 @@ type ExecEngine interface {
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
 }
 
+type DACClient interface {
+	UploadBlobs(context.Context, *eth.ExecutionPayloadEnvelope) error
+}
+
 type EngineController struct {
 	engine     ExecEngine // Underlying execution engine RPC
 	log        log.Logger
@@ -75,19 +79,15 @@ type EngineController struct {
 	buildingSafe bool
 	safeAttrs    *AttributesWithParent
 
-	dacClient rollup.DACClient
+	dacClient DACClient
 }
 
-func NewEngineController(engine ExecEngine, log log.Logger, metrics Metrics, rollupCfg *rollup.Config, syncMode sync.Mode) *EngineController {
+func NewEngineController(engine ExecEngine, log log.Logger, metrics Metrics, rollupCfg *rollup.Config, syncMode sync.Mode, dacClient DACClient) *EngineController {
 	syncStatus := syncStatusCL
 	if syncMode == sync.ELSync {
 		syncStatus = syncStatusWillStartEL
 	}
 
-	var dacClient rollup.DACClient
-	if dacConfig := rollupCfg.DACConfig(); dacConfig != nil {
-		dacClient = dacConfig.Client()
-	}
 	return &EngineController{
 		engine:     engine,
 		log:        log,

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -251,7 +251,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 	prev := &fakeAttributesQueue{}
 
-	ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync, nil)
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
@@ -487,7 +487,7 @@ func TestEngineQueue_ResetWhenUnsafeOriginNotCanonical(t *testing.T) {
 
 	prev := &fakeAttributesQueue{origin: refE}
 
-	ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync, nil)
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
@@ -817,7 +817,7 @@ func TestVerifyNewL1Origin(t *testing.T) {
 			}, nil)
 
 			prev := &fakeAttributesQueue{origin: refE}
-			ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync)
+			ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync, nil)
 			eq := NewEngineQueue(logger, cfg, eng, ec, metrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 			require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
@@ -914,7 +914,7 @@ func TestBlockBuildingRace(t *testing.T) {
 	}
 
 	prev := &fakeAttributesQueue{origin: refA, attrs: attrs, islastInSpan: true}
-	ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(eng, logger, metrics, &rollup.Config{}, sync.CLSync, nil)
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
 
@@ -1086,7 +1086,7 @@ func TestResetLoop(t *testing.T) {
 
 	prev := &fakeAttributesQueue{origin: refA, attrs: attrs, islastInSpan: true}
 
-	ec := NewEngineController(eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync, nil)
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics.NoopMetrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	eq.ec.SetUnsafeHead(refA2)
 	eq.ec.SetSafeHead(refA1)
@@ -1192,7 +1192,7 @@ func TestEngineQueue_StepPopOlderUnsafe(t *testing.T) {
 
 	prev := &fakeAttributesQueue{origin: refA}
 
-	ec := NewEngineController(eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync, nil)
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics.NoopMetrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	eq.ec.SetUnsafeHead(refA2)
 	eq.ec.SetSafeHead(refA0)
@@ -1273,7 +1273,7 @@ func TestPlasmaFinalityData(t *testing.T) {
 		SequenceNumber: 1,
 	}
 
-	ec := NewEngineController(eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync)
+	ec := NewEngineController(eng, logger, metrics.NoopMetrics, &rollup.Config{}, sync.CLSync, nil)
 
 	eq := NewEngineQueue(logger, cfg, eng, ec, metrics.NoopMetrics, prev, l1F, &sync.Config{}, safedb.Disabled)
 	require.Equal(t, expFinalityLookback, cap(eq.finalityData))

--- a/op-node/rollup/derive/engine_update.go
+++ b/op-node/rollup/derive/engine_update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -129,7 +128,7 @@ func confirmPayload(
 	updateSafe bool,
 	agossip async.AsyncGossiper,
 	sequencerConductor conductor.SequencerConductor,
-	dacClient rollup.DACClient,
+	dacClient DACClient,
 ) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error) {
 	var envelope *eth.ExecutionPayloadEnvelope
 	// if the payload is available from the async gossiper, it means it was not yet imported, so we reuse it

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -130,13 +130,14 @@ func NewDriver(
 	syncCfg *sync.Config,
 	sequencerConductor conductor.SequencerConductor,
 	plasma derive.PlasmaInputFetcher,
+	dacClient derive.DACClient,
 ) *Driver {
 	l1 = NewMeteredL1Fetcher(l1, metrics)
 	l1State := NewL1State(log, metrics)
 	sequencerConfDepth := NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
 	findL1Origin := NewL1OriginSelector(log, cfg, sequencerConfDepth)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)
-	engine := derive.NewEngineController(l2, log, metrics, cfg, syncCfg.SyncMode)
+	engine := derive.NewEngineController(l2, log, metrics, cfg, syncCfg.SyncMode, dacClient)
 	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, plasma, l2, engine, metrics, syncCfg, safeHeadListener)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 	meteredEngine := NewMeteredEngine(cfg, engine, metrics, log) // Only use the metered engine in the sequencer b/c it records sequencing metrics.

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethstorage/da-server/pkg/da/client"
 
 	plasma "github.com/ethereum-optimism/optimism/op-plasma"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -149,20 +148,7 @@ type Config struct {
 }
 
 type L2BlobConfig struct {
-	DACConfig  *DACConfig `json:"dac_config,omitempty"`
-	L2BlobTime *uint64    `json:"l2BlobTime,omitempty"`
-}
-type DACConfig struct {
-	URLS []string `json:"urls,omitempty"`
-}
-
-type DACClient interface {
-	UploadBlobs(context.Context, *eth.ExecutionPayloadEnvelope) error
-}
-
-func (dacConfig *DACConfig) Client() DACClient {
-
-	return client.New(dacConfig.URLS)
+	L2BlobTime *uint64 `json:"l2BlobTime,omitempty"`
 }
 
 // IsL2Blob returns whether l2 blob is enabled
@@ -170,11 +156,9 @@ func (cfg *Config) IsL2Blob(parentTime uint64) bool {
 	return cfg.L2BlobConfig != nil && *cfg.L2BlobConfig.L2BlobTime <= parentTime
 }
 
-func (cfg *Config) DACConfig() *DACConfig {
-	if cfg.L2BlobConfig == nil {
-		return nil
-	}
-	return cfg.L2BlobConfig.DACConfig
+// IsL2BlobTimeSet returns whether l2 blob activation time is set
+func (cfg *Config) IsL2BlobTimeSet() bool {
+	return cfg.L2BlobConfig != nil && cfg.L2BlobConfig.L2BlobTime != nil
 }
 
 // ValidateL1Config checks L1 config variables for errors.

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -110,7 +110,8 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		ConductorRpc:        ctx.String(flags.ConductorRpcFlag.Name),
 		ConductorRpcTimeout: ctx.Duration(flags.ConductorRpcTimeoutFlag.Name),
 
-		Plasma: plasma.ReadCLIConfig(ctx),
+		Plasma:    plasma.ReadCLIConfig(ctx),
+		DACConfig: node.ReadDACConfigFromCLI(ctx),
 	}
 
 	if err := cfg.LoadPersisted(log); err != nil {

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -40,7 +40,7 @@ type Driver struct {
 }
 
 func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher, l1BlobsSource derive.L1BlobsFetcher, l2Source L2Source, targetBlockNum uint64) *Driver {
-	engine := derive.NewEngineController(l2Source, logger, metrics.NoopMetrics, cfg, sync.CLSync)
+	engine := derive.NewEngineController(l2Source, logger, metrics.NoopMetrics, cfg, sync.CLSync, nil)
 	pipeline := derive.NewDerivationPipeline(logger, cfg, l1Source, l1BlobsSource, plasma.Disabled, l2Source, engine, metrics.NoopMetrics, &sync.Config{}, safedb.Disabled)
 	pipeline.Reset()
 	return &Driver{


### PR DESCRIPTION
This PR fixes [this](https://github.com/ethstorage/optimism/issues/57) issue.

**UPDATE**

`rollup.Config` is supposed to only contain core configuration values, peripheral parameters such as DACConfig should be passed from CLI instead.

This PR moves DACConfig from `rollup.Config` to CLI.