### PR TITLE
op-node: fix incorrect inbox check in receipt

### DIFF
--- a/op-node/rollup/derive/calldata_source_test.go
+++ b/op-node/rollup/derive/calldata_source_test.go
@@ -121,7 +121,7 @@ func TestDataFromEVMTransactions(t *testing.T) {
 			}
 		}
 
-		out := DataFromEVMTransactions(DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress, false, false}, batcherAddr, txs, testlog.Logger(t, log.LevelCrit), nil)
+		out := DataFromEVMTransactions(DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress, false}, batcherAddr, txs, testlog.Logger(t, log.LevelCrit))
 		require.ElementsMatch(t, expectedData, out)
 	}
 


### PR DESCRIPTION
This fixes #73.  The issue here is that the code incorrectly uses `receipt.contractAddress` to check `inboxAddress`. The fix here will filter the txs with success status and `tx.to == inboxAddress`.

Test:
- Run `make devnet-up`
- Run `cast bn safe -r http://localhost:9545` , and observe an increasing number
- Run `docker logs ops-bedrock-op-node-1`, and observe the new batches are retrieved from L1 during derivation.