### PR TITLE
l2 blob passed fault proof

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -425,6 +425,7 @@ var optionalFlags = []cli.Flag{
 	ConductorRpcTimeoutFlag,
 	SafeDBPath,
 	L2EngineKind,
+	DACUrlsFlag,
 }
 
 var DeprecatedFlags = []cli.Flag{

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -129,6 +129,7 @@ services:
       --altda.enabled=${ALTDA_ENABLED}
       --altda.da-service=${ALTDA_SERVICE}
       --altda.da-server=http://da-server:3100
+      --dac.urls=
     ports:
       - "7545:8545"
       - "9003:9003"

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -49,6 +49,7 @@
   "l2GenesisEcotoneTimeOffset": "0x0",
   "l2GenesisFjordTimeOffset": "0x0",
   "l2GenesisGraniteTimeOffset": "0x0",
+  "l2GenesisBlobTimeOffset": "0xffffffff",
   "l1CancunTimeOffset": "0x0",
   "systemConfigStartBlock": 0,
   "requiredProtocolVersion": "0x0000000000000000000000000000000000000000000000000000000000000001",


### PR DESCRIPTION
This PR aims to pass fault-proof with l2 blob txs.

The key missing part in the op-program is the calculation of `BlobGasUsed` and `ExcessBlobGas`, which results in mismatched claims between the op-program and op-node.

Tests:
1. Run DA server
2. Enable L2 blob (l2GenesisBlobTimeOffset to 0) and set --dac.urls
3. Send a tx ```cast send $ADDR --private-key $PK --blob --path <file> -r $L2``` with 4 BLOBs
4. `make verify-devnet`
5. check if the blobs were written to da server db