### PR TITLE
feat(MSFDG): support attackV2 & stepV2 for MSFDG contract

### DIFF
--- a/op-challenger2/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger2/game/fault/contracts/faultdisputegame.go
@@ -54,6 +54,10 @@ var (
 	methodL2BlockNumberChallenged = "l2BlockNumberChallenged"
 	methodL2BlockNumberChallenger = "l2BlockNumberChallenger"
 	methodChallengeRootL2Block    = "challengeRootL2Block"
+	methodNBits                   = "nBits"
+	methodMaxAttackBranch         = "maxAttackBranch"
+	methodAttackV2                = "attackV2"
+	methodStepV2                  = "stepV2"
 )
 
 var (
@@ -81,7 +85,7 @@ type outputRootProof struct {
 }
 
 func NewFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMetricer, addr common.Address, caller *batching.MultiCaller) (FaultDisputeGameContract, error) {
-	contractAbi := snapshots.LoadFaultDisputeGameABI()
+	contractAbi := snapshots.LoadFaultDisputeGameNABI()
 
 	result, err := caller.SingleCall(ctx, rpcblock.Latest, batching.NewContractCall(contractAbi, addr, methodVersion))
 	if err != nil {
@@ -324,6 +328,7 @@ func (f *FaultDisputeGameContractLatest) addLocalDataTx(claimIdx uint64, data *t
 		data.GetIdent(),
 		new(big.Int).SetUint64(claimIdx),
 		new(big.Int).SetUint64(uint64(data.OracleOffset)),
+		data.OutputRootDAItem,
 	)
 	return call.ToTxCandidate()
 }
@@ -592,6 +597,43 @@ func (f *FaultDisputeGameContractLatest) decodeClaim(result *batching.CallResult
 	}
 }
 
+func (f *FaultDisputeGameContractLatest) GetNBits(ctx context.Context) (uint64, error) {
+	defer f.metrics.StartContractRequest("GetNBits")()
+	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodNBits))
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch nbits: %w", err)
+	}
+	return result.GetBigInt(0).Uint64(), nil
+}
+
+func (f *FaultDisputeGameContractLatest) GetMaxAttackBranch(ctx context.Context) (uint64, error) {
+	defer f.metrics.StartContractRequest("GetMaxAttackBranch")()
+	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, f.contract.Call(methodMaxAttackBranch))
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch max attack branch: %w", err)
+	}
+	return result.GetBigInt(0).Uint64(), nil
+}
+
+func (f *FaultDisputeGameContractLatest) AttackV2Tx(ctx context.Context, parent types.Claim, attackBranch uint64, daType uint64, claims []byte) (txmgr.TxCandidate, error) {
+	nBits, err := f.GetNBits(ctx)
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("failed to retrieve nbits: %w", err)
+	}
+	call := f.contract.Call(methodAttackV2,
+		parent.Value,
+		big.NewInt(int64(parent.ContractIndex)),
+		new(big.Int).SetUint64(attackBranch),
+		new(big.Int).SetUint64(daType),
+		claims)
+	return f.txWithBond(ctx, parent.Position.MoveN(nBits, attackBranch), call)
+}
+
+func (f *FaultDisputeGameContractLatest) StepV2Tx(claimIdx uint64, attackBranch uint64, stateData []byte, proof types.StepProof) (txmgr.TxCandidate, error) {
+	call := f.contract.Call(methodStepV2, new(big.Int).SetUint64(claimIdx), new(big.Int).SetUint64(attackBranch), stateData, proof)
+	return call.ToTxCandidate()
+}
+
 type FaultDisputeGameContract interface {
 	GetBalance(ctx context.Context, block rpcblock.Block) (*big.Int, common.Address, error)
 	GetBlockRange(ctx context.Context) (prestateBlock uint64, poststateBlock uint64, retErr error)
@@ -624,4 +666,8 @@ type FaultDisputeGameContract interface {
 	ResolveClaimTx(claimIdx uint64) (txmgr.TxCandidate, error)
 	CallResolve(ctx context.Context) (gameTypes.GameStatus, error)
 	ResolveTx() (txmgr.TxCandidate, error)
+	AttackV2Tx(ctx context.Context, parent types.Claim, attackBranch uint64, daType uint64, claims []byte) (txmgr.TxCandidate, error)
+	StepV2Tx(claimIdx uint64, attackBranch uint64, stateData []byte, proof types.StepProof) (txmgr.TxCandidate, error)
+	GetNBits(ctx context.Context) (uint64, error)
+	GetMaxAttackBranch(ctx context.Context) (uint64, error)
 }

--- a/op-challenger2/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger2/game/fault/contracts/faultdisputegame_test.go
@@ -803,12 +803,11 @@ func TestAttackV2Tx(t *testing.T) {
 		t.Run(version.version, func(t *testing.T) {
 			stubRpc, game := setupFaultDisputeGameTest(t, version)
 			bond := big.NewInt(1044)
-			value := common.Hash{0xaa}
-			var claims [96]byte
-			copy(claims[0:32], value[:])
-			copy(claims[32:64], value[:])
-			copy(claims[64:96], value[:])
 			nBits := uint64(2)
+			claims := make([]byte, ((1<<nBits)-1)*32)
+			for i := range claims {
+				claims[i] = common.Hash{0xaa}[i%32]
+			}
 			attackBranch := big.NewInt(0)
 			daType := big.NewInt(1)
 			parent := faultTypes.Claim{ClaimData: faultTypes.ClaimData{Value: common.Hash{0xbb}}, ContractIndex: 111}

--- a/op-challenger2/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger2/game/fault/contracts/faultdisputegame_test.go
@@ -51,26 +51,8 @@ const (
 
 var versions = []contractVersion{
 	{
-		version: vers080,
-		loadAbi: func() *abi.ABI {
-			return mustParseAbi(faultDisputeGameAbi020)
-		},
-	},
-	{
-		version: vers0180,
-		loadAbi: func() *abi.ABI {
-			return mustParseAbi(faultDisputeGameAbi0180)
-		},
-	},
-	{
-		version: vers111,
-		loadAbi: func() *abi.ABI {
-			return mustParseAbi(faultDisputeGameAbi111)
-		},
-	},
-	{
 		version: versLatest,
-		loadAbi: snapshots.LoadFaultDisputeGameABI,
+		loadAbi: snapshots.LoadFaultDisputeGameNABI,
 	},
 }
 
@@ -156,6 +138,24 @@ func TestSimpleGetters(t *testing.T) {
 			result:      types.GameStatusInProgress,
 			call: func(game FaultDisputeGameContract) (any, error) {
 				return game.CallResolve(context.Background())
+			},
+		},
+		{
+			methodAlias: "nBits",
+			method:      methodNBits,
+			result:      big.NewInt(2),
+			expected:    uint64(2),
+			call: func(game FaultDisputeGameContract) (any, error) {
+				return game.GetNBits(context.Background())
+			},
+		},
+		{
+			methodAlias: "maxAttackBranch",
+			method:      methodMaxAttackBranch,
+			result:      big.NewInt(3),
+			expected:    uint64(3),
+			call: func(game FaultDisputeGameContract) (any, error) {
+				return game.GetMaxAttackBranch(context.Background())
 			},
 		},
 	}
@@ -556,21 +556,30 @@ func TestGetStartingRootHash(t *testing.T) {
 func TestFaultDisputeGame_UpdateOracleTx(t *testing.T) {
 	for _, version := range versions {
 		version := version
+		outputRootDAItem := faultTypes.DAItem{
+			DaType:   faultTypes.CallDataType,
+			DataHash: common.Hash{},
+			Proof:    []byte{},
+		}
+		vmStateDA := faultTypes.DAData{
+			PreDA:  outputRootDAItem,
+			PostDA: outputRootDAItem,
+		}
 		t.Run(version.version, func(t *testing.T) {
 			t.Run("Local", func(t *testing.T) {
 				stubRpc, game := setupFaultDisputeGameTest(t, version)
-				data := faultTypes.NewPreimageOracleData(common.Hash{0x01, 0xbc}.Bytes(), []byte{1, 2, 3, 4, 5, 6, 7}, 16)
+				data := faultTypes.NewPreimageOracleDAData(common.Hash{0x01, 0xbc}.Bytes(), []byte{1, 2, 3, 4, 5, 6, 7}, 16, vmStateDA, outputRootDAItem)
 				claimIdx := uint64(6)
 				stubRpc.SetResponse(fdgAddr, methodAddLocalData, rpcblock.Latest, []interface{}{
 					data.GetIdent(),
 					new(big.Int).SetUint64(claimIdx),
 					new(big.Int).SetUint64(uint64(data.OracleOffset)),
+					outputRootDAItem,
 				}, nil)
 				tx, err := game.UpdateOracleTx(context.Background(), claimIdx, data)
 				require.NoError(t, err)
 				stubRpc.VerifyTxCandidate(tx)
 			})
-
 			t.Run("Global", func(t *testing.T) {
 				stubRpc, game := setupFaultDisputeGameTest(t, version)
 				data := faultTypes.NewPreimageOracleData(common.Hash{0x02, 0xbc}.Bytes(), []byte{1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15}, 16)
@@ -786,4 +795,60 @@ func setupFaultDisputeGameTest(t *testing.T, version contractVersion) (*batching
 	game, err := NewFaultDisputeGameContract(context.Background(), contractMetrics.NoopContractMetrics, fdgAddr, caller)
 	require.NoError(t, err)
 	return stubRpc, game
+}
+
+func TestAttackV2Tx(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, game := setupFaultDisputeGameTest(t, version)
+			bond := big.NewInt(1044)
+			value := common.Hash{0xaa}
+			var claims [96]byte
+			copy(claims[0:32], value[:])
+			copy(claims[32:64], value[:])
+			copy(claims[64:96], value[:])
+			nBits := uint64(2)
+			attackBranch := big.NewInt(0)
+			daType := big.NewInt(1)
+			parent := faultTypes.Claim{ClaimData: faultTypes.ClaimData{Value: common.Hash{0xbb}}, ContractIndex: 111}
+			stubRpc.SetResponse(fdgAddr, methodNBits, rpcblock.Latest, nil, []interface{}{new(big.Int).SetUint64(nBits)})
+			stubRpc.SetResponse(fdgAddr, methodRequiredBond, rpcblock.Latest, []interface{}{parent.Position.MoveN(nBits, attackBranch.Uint64()).ToGIndex()}, []interface{}{bond})
+			stubRpc.SetResponse(fdgAddr, methodAttackV2, rpcblock.Latest, []interface{}{parent.Value, big.NewInt(111), attackBranch, daType, claims[:]}, nil)
+			tx, err := game.AttackV2Tx(context.Background(), parent, attackBranch.Uint64(), daType.Uint64(), claims[:])
+			require.NoError(t, err)
+			stubRpc.VerifyTxCandidate(tx)
+			require.Equal(t, bond, tx.Value)
+		})
+	}
+}
+
+func TestStepV2Tx(t *testing.T) {
+	for _, version := range versions {
+		version := version
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, game := setupFaultDisputeGameTest(t, version)
+			stateData := []byte{1, 2, 3}
+			vmProof := []byte{4, 5, 6, 7, 8, 9}
+			pre := faultTypes.DAItem{
+				DaType:   faultTypes.CallDataType,
+				DataHash: [32]byte{0x01, 0x02, 0x03},
+				Proof:    []byte("pre state proof"),
+			}
+			post := faultTypes.DAItem{
+				DaType:   faultTypes.CallDataType,
+				DataHash: [32]byte{0x04, 0x05, 0x06},
+				Proof:    []byte("post state proof"),
+			}
+			proofData := faultTypes.StepProof{
+				PreStateItem:  pre,
+				PostStateItem: post,
+				VmProof:       vmProof,
+			}
+			stubRpc.SetResponse(fdgAddr, methodStepV2, rpcblock.Latest, []interface{}{big.NewInt(111), big.NewInt(1), stateData, proofData}, nil)
+			tx, err := game.StepV2Tx(111, 1, stateData, proofData)
+			require.NoError(t, err)
+			stubRpc.VerifyTxCandidate(tx)
+		})
+	}
 }

--- a/op-challenger2/game/fault/types/position.go
+++ b/op-challenger2/game/fault/types/position.go
@@ -154,3 +154,17 @@ func bigMSB(x *big.Int) Depth {
 	}
 	return Depth(x.BitLen() - 1)
 }
+
+func (p Position) MoveN(depth uint64, branch uint64) Position {
+	return Position{
+		depth:        p.depth + Depth(depth),
+		indexAtDepth: new(big.Int).Add(p.IndexAtDepth(), new(big.Int).Lsh(big.NewInt(int64(branch)), uint(depth))),
+	}
+}
+
+func (p Position) MoveRightN(number uint64) Position {
+	return Position{
+		depth:        p.depth,
+		indexAtDepth: new(big.Int).Add(p.IndexAtDepth(), big.NewInt(int64(number))),
+	}
+}

--- a/op-challenger2/game/fault/types/position_test.go
+++ b/op-challenger2/game/fault/types/position_test.go
@@ -314,3 +314,70 @@ func TestRelativeMoves(t *testing.T) {
 		})
 	}
 }
+
+func TestMoveN(t *testing.T) {
+	tests0 := []struct {
+		startGIndex  *big.Int
+		defendGIndex *big.Int
+	}{
+		{bi(1), bi(4)},
+		{bi(2), bi(8)},
+		{bi(4), bi(16)},
+	}
+	depth := uint64(2)
+	branch := uint64(0)
+	for _, test := range tests0 {
+		pos := NewPositionFromGIndex(test.startGIndex)
+		result := pos.MoveN(depth, branch)
+		require.Equalf(t, test.defendGIndex, result.ToGIndex(), "move GIndex %s, expected=%s, got=%s", test.startGIndex, test.defendGIndex, result.ToGIndex())
+	}
+
+	tests1 := []struct {
+		startGIndex  *big.Int
+		defendGIndex *big.Int
+	}{
+		{bi(2), bi(12)},
+		{bi(4), bi(20)},
+		{bi(8), bi(36)},
+	}
+	depth = uint64(2)
+	branch = uint64(1)
+	for _, test := range tests1 {
+		pos := NewPositionFromGIndex(test.startGIndex)
+		result := pos.MoveN(depth, branch)
+		require.Equalf(t, test.defendGIndex, result.ToGIndex(), "move GIndex %s, expected=%s, got=%s", test.startGIndex, test.defendGIndex, result.ToGIndex())
+	}
+
+	tests3 := []struct {
+		startGIndex  *big.Int
+		defendGIndex *big.Int
+	}{
+		{bi(4), bi(28)},
+		{bi(8), bi(44)},
+	}
+	depth = uint64(2)
+	branch = uint64(3)
+	for _, test := range tests3 {
+		pos := NewPositionFromGIndex(test.startGIndex)
+		result := pos.MoveN(depth, branch)
+		require.Equalf(t, test.defendGIndex, result.ToGIndex(), "move GIndex %s, expected=%s, got=%s", test.startGIndex, test.defendGIndex, result.ToGIndex())
+	}
+}
+
+func TestMoveRightN(t *testing.T) {
+	tests := []struct {
+		startGIndex  *big.Int
+		moveN        uint64
+		defendGIndex *big.Int
+	}{
+		{bi(2), 1, bi(3)},
+		{bi(4), 2, bi(6)},
+		{bi(8), 4, bi(12)},
+		{bi(17), 4, bi(21)},
+	}
+	for _, test := range tests {
+		pos := NewPositionFromGIndex(test.startGIndex)
+		result := pos.MoveRightN(test.moveN)
+		require.Equalf(t, test.defendGIndex, result.ToGIndex(), "move GIndex %s, MoveN %s, expected=%s, got=%s", test.startGIndex, test.moveN, test.defendGIndex, result.ToGIndex())
+	}
+}

--- a/op-challenger2/game/fault/types/position_test.go
+++ b/op-challenger2/game/fault/types/position_test.go
@@ -317,8 +317,8 @@ func TestRelativeMoves(t *testing.T) {
 
 func TestMoveN(t *testing.T) {
 	tests0 := []struct {
-		startGIndex  *big.Int
-		defendGIndex *big.Int
+		startGIndex *big.Int
+		postGIndex  *big.Int
 	}{
 		{bi(1), bi(4)},
 		{bi(2), bi(8)},
@@ -329,12 +329,12 @@ func TestMoveN(t *testing.T) {
 	for _, test := range tests0 {
 		pos := NewPositionFromGIndex(test.startGIndex)
 		result := pos.MoveN(depth, branch)
-		require.Equalf(t, test.defendGIndex, result.ToGIndex(), "move GIndex %s, expected=%s, got=%s", test.startGIndex, test.defendGIndex, result.ToGIndex())
+		require.Equalf(t, test.postGIndex, result.ToGIndex(), "move GIndex %s, expected=%s, got=%s", test.startGIndex, test.postGIndex, result.ToGIndex())
 	}
 
 	tests1 := []struct {
-		startGIndex  *big.Int
-		defendGIndex *big.Int
+		startGIndex *big.Int
+		postGIndex  *big.Int
 	}{
 		{bi(2), bi(12)},
 		{bi(4), bi(20)},
@@ -345,7 +345,7 @@ func TestMoveN(t *testing.T) {
 	for _, test := range tests1 {
 		pos := NewPositionFromGIndex(test.startGIndex)
 		result := pos.MoveN(depth, branch)
-		require.Equalf(t, test.defendGIndex, result.ToGIndex(), "move GIndex %s, expected=%s, got=%s", test.startGIndex, test.defendGIndex, result.ToGIndex())
+		require.Equalf(t, test.postGIndex, result.ToGIndex(), "move GIndex %s, expected=%s, got=%s", test.startGIndex, test.postGIndex, result.ToGIndex())
 	}
 
 	tests3 := []struct {

--- a/op-challenger2/game/fault/types/position_test.go
+++ b/op-challenger2/game/fault/types/position_test.go
@@ -349,8 +349,8 @@ func TestMoveN(t *testing.T) {
 	}
 
 	tests3 := []struct {
-		startGIndex  *big.Int
-		defendGIndex *big.Int
+		startGIndex *big.Int
+		postGIndex  *big.Int
 	}{
 		{bi(4), bi(28)},
 		{bi(8), bi(44)},
@@ -360,15 +360,15 @@ func TestMoveN(t *testing.T) {
 	for _, test := range tests3 {
 		pos := NewPositionFromGIndex(test.startGIndex)
 		result := pos.MoveN(depth, branch)
-		require.Equalf(t, test.defendGIndex, result.ToGIndex(), "move GIndex %s, expected=%s, got=%s", test.startGIndex, test.defendGIndex, result.ToGIndex())
+		require.Equalf(t, test.postGIndex, result.ToGIndex(), "move GIndex %s, expected=%s, got=%s", test.startGIndex, test.postGIndex, result.ToGIndex())
 	}
 }
 
 func TestMoveRightN(t *testing.T) {
 	tests := []struct {
-		startGIndex  *big.Int
-		moveN        uint64
-		defendGIndex *big.Int
+		startGIndex *big.Int
+		moveN       uint64
+		postGIndex  *big.Int
 	}{
 		{bi(2), 1, bi(3)},
 		{bi(4), 2, bi(6)},
@@ -378,6 +378,6 @@ func TestMoveRightN(t *testing.T) {
 	for _, test := range tests {
 		pos := NewPositionFromGIndex(test.startGIndex)
 		result := pos.MoveRightN(test.moveN)
-		require.Equalf(t, test.defendGIndex, result.ToGIndex(), "move GIndex %s, MoveN %s, expected=%s, got=%s", test.startGIndex, test.moveN, test.defendGIndex, result.ToGIndex())
+		require.Equalf(t, test.postGIndex, result.ToGIndex(), "move GIndex %s, MoveN %s, expected=%s, got=%s", test.startGIndex, test.moveN, test.postGIndex, result.ToGIndex())
 	}
 }

--- a/op-challenger2/game/fault/types/types.go
+++ b/op-challenger2/game/fault/types/types.go
@@ -41,6 +41,33 @@ type PreimageOracleData struct {
 	BlobFieldIndex uint64
 	BlobCommitment []byte
 	BlobProof      []byte
+	// multi-sec proof for VM step
+	VMStateDA DAData
+	// daitem for addLocalData
+	OutputRootDAItem DAItem
+}
+
+var (
+	CallDataType = big.NewInt(0)
+	BlobDataType = big.NewInt(1)
+)
+
+type DAItem struct {
+	DaType   *big.Int
+	DataHash common.Hash
+	Proof    []byte
+}
+
+// Provide DA proof for addLocalData's outputRoot and stepV2's stateRoot
+type DAData struct {
+	PreDA  DAItem
+	PostDA DAItem
+}
+
+type StepProof struct {
+	PreStateItem  DAItem
+	PostStateItem DAItem
+	VmProof       []byte
 }
 
 // GetIdent returns the ident for the preimage oracle data.
@@ -73,6 +100,17 @@ func NewPreimageOracleData(key []byte, data []byte, offset uint32) *PreimageOrac
 		OracleKey:    key,
 		oracleData:   data,
 		OracleOffset: offset,
+	}
+}
+
+func NewPreimageOracleDAData(key []byte, data []byte, offset uint32, vmStateDA DAData, outputRootDAItem DAItem) *PreimageOracleData {
+	return &PreimageOracleData{
+		IsLocal:          len(key) > 0 && key[0] == byte(preimage.LocalKeyType),
+		OracleKey:        key,
+		oracleData:       data,
+		OracleOffset:     offset,
+		VMStateDA:        vmStateDA,
+		OutputRootDAItem: outputRootDAItem,
 	}
 }
 

--- a/packages/contracts-bedrock/snapshots/abi/FaultDisputeGameN.json
+++ b/packages/contracts-bedrock/snapshots/abi/FaultDisputeGameN.json
@@ -1,0 +1,1292 @@
+[
+    {
+        "type": "constructor",
+        "inputs": [
+            {
+                "name": "_gameType",
+                "type": "uint32",
+                "internalType": "GameType"
+            },
+            {
+                "name": "_absolutePrestate",
+                "type": "bytes32",
+                "internalType": "Claim"
+            },
+            {
+                "name": "_maxGameDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_splitDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_clockExtension",
+                "type": "uint64",
+                "internalType": "Duration"
+            },
+            {
+                "name": "_maxClockDuration",
+                "type": "uint64",
+                "internalType": "Duration"
+            },
+            {
+                "name": "_vm",
+                "type": "address",
+                "internalType": "contract IBigStepper"
+            },
+            {
+                "name": "_weth",
+                "type": "address",
+                "internalType": "contract IDelayedWETH"
+            },
+            {
+                "name": "_anchorStateRegistry",
+                "type": "address",
+                "internalType": "contract IAnchorStateRegistry"
+            },
+            {
+                "name": "_l2ChainId",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "MAX_ATTACK_BRANCH",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "N_BITS",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "absolutePrestate",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "absolutePrestate_",
+                "type": "bytes32",
+                "internalType": "Claim"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "addLocalData",
+        "inputs": [
+            {
+                "name": "_ident",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_execLeafIdx",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_partOffset",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_daItem",
+                "type": "tuple",
+                "internalType": "struct LibDA.DAItem",
+                "components": [
+                    {
+                        "name": "daType",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "dataHash",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "proof",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            }
+        ],
+        "outputs": [
+            {
+                "name": "uuid_",
+                "type": "bytes32",
+                "internalType": "Hash"
+            },
+            {
+                "name": "value_",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "addLocalData",
+        "inputs": [
+            {
+                "name": "_ident",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_execLeafIdx",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_partOffset",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "anchorStateRegistry",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "registry_",
+                "type": "address",
+                "internalType": "contract IAnchorStateRegistry"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "attack",
+        "inputs": [
+            {
+                "name": "_disputed",
+                "type": "bytes32",
+                "internalType": "Claim"
+            },
+            {
+                "name": "_parentIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_claim",
+                "type": "bytes32",
+                "internalType": "Claim"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "attackV2",
+        "inputs": [
+            {
+                "name": "_disputed",
+                "type": "bytes32",
+                "internalType": "Claim"
+            },
+            {
+                "name": "_parentIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_attackBranch",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_daType",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_claims",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "challengeRootL2Block",
+        "inputs": [
+            {
+                "name": "_outputRootProof",
+                "type": "tuple",
+                "internalType": "struct Types.OutputRootProof",
+                "components": [
+                    {
+                        "name": "version",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "stateRoot",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "messagePasserStorageRoot",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "latestBlockhash",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    }
+                ]
+            },
+            {
+                "name": "_headerRLP",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "claimCredit",
+        "inputs": [
+            {
+                "name": "_recipient",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "claimData",
+        "inputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "parentIndex",
+                "type": "uint32",
+                "internalType": "uint32"
+            },
+            {
+                "name": "counteredBy",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "claimant",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "bond",
+                "type": "uint128",
+                "internalType": "uint128"
+            },
+            {
+                "name": "claim",
+                "type": "bytes32",
+                "internalType": "Claim"
+            },
+            {
+                "name": "position",
+                "type": "uint128",
+                "internalType": "Position"
+            },
+            {
+                "name": "clock",
+                "type": "uint128",
+                "internalType": "Clock"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "claimDataLen",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "len_",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "claims",
+        "inputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "Hash"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "clockExtension",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "clockExtension_",
+                "type": "uint64",
+                "internalType": "Duration"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "createdAt",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint64",
+                "internalType": "Timestamp"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "credit",
+        "inputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "defend",
+        "inputs": [
+            {
+                "name": "_disputed",
+                "type": "bytes32",
+                "internalType": "Claim"
+            },
+            {
+                "name": "_parentIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_claim",
+                "type": "bytes32",
+                "internalType": "Claim"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "extraData",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "extraData_",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "gameCreator",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "creator_",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "gameData",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "gameType_",
+                "type": "uint32",
+                "internalType": "GameType"
+            },
+            {
+                "name": "rootClaim_",
+                "type": "bytes32",
+                "internalType": "Claim"
+            },
+            {
+                "name": "extraData_",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "gameType",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "gameType_",
+                "type": "uint32",
+                "internalType": "GameType"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getChallengerDuration",
+        "inputs": [
+            {
+                "name": "_claimIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "duration_",
+                "type": "uint64",
+                "internalType": "Duration"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getNumToResolve",
+        "inputs": [
+            {
+                "name": "_claimIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "numRemainingChildren_",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getRequiredBond",
+        "inputs": [
+            {
+                "name": "_position",
+                "type": "uint128",
+                "internalType": "Position"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "requiredBond_",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "initialize",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "l1Head",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "l1Head_",
+                "type": "bytes32",
+                "internalType": "Hash"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "l2BlockNumber",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "l2BlockNumber_",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "l2BlockNumberChallenged",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "l2BlockNumberChallenger",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "l2ChainId",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "l2ChainId_",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "maxAttackBranch",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "maxAttackBranch_",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "maxClockDuration",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "maxClockDuration_",
+                "type": "uint64",
+                "internalType": "Duration"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "maxGameDepth",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "maxGameDepth_",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "move",
+        "inputs": [
+            {
+                "name": "_disputed",
+                "type": "bytes32",
+                "internalType": "Claim"
+            },
+            {
+                "name": "_challengeIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_claim",
+                "type": "bytes32",
+                "internalType": "Claim"
+            },
+            {
+                "name": "_isAttack",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "nBits",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "nBits_",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "resolutionCheckpoints",
+        "inputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "initialCheckpointComplete",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "subgameIndex",
+                "type": "uint32",
+                "internalType": "uint32"
+            },
+            {
+                "name": "leftmostPosition",
+                "type": "uint128",
+                "internalType": "Position"
+            },
+            {
+                "name": "counteredBy",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "resolve",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "status_",
+                "type": "uint8",
+                "internalType": "enum GameStatus"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "resolveClaim",
+        "inputs": [
+            {
+                "name": "_claimIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_numToResolve",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "resolvedAt",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint64",
+                "internalType": "Timestamp"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "resolvedSubgames",
+        "inputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "rootClaim",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "rootClaim_",
+                "type": "bytes32",
+                "internalType": "Claim"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "name": "splitDepth",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "splitDepth_",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "startingBlockNumber",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "startingBlockNumber_",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "startingOutputRoot",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "root",
+                "type": "bytes32",
+                "internalType": "Hash"
+            },
+            {
+                "name": "l2BlockNumber",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "startingRootHash",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "startingRootHash_",
+                "type": "bytes32",
+                "internalType": "Hash"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "status",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint8",
+                "internalType": "enum GameStatus"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "step",
+        "inputs": [
+            {
+                "name": "_claimIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_isAttack",
+                "type": "bool",
+                "internalType": "bool"
+            },
+            {
+                "name": "_stateData",
+                "type": "bytes",
+                "internalType": "bytes"
+            },
+            {
+                "name": "_proof",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "stepV2",
+        "inputs": [
+            {
+                "name": "_claimIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_attackBranch",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_stateData",
+                "type": "bytes",
+                "internalType": "bytes"
+            },
+            {
+                "name": "_proof",
+                "type": "tuple",
+                "internalType": "struct FaultDisputeGame.StepProof",
+                "components": [
+                    {
+                        "name": "preStateItem",
+                        "type": "tuple",
+                        "internalType": "struct LibDA.DAItem",
+                        "components": [
+                            {
+                                "name": "daType",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            },
+                            {
+                                "name": "dataHash",
+                                "type": "bytes32",
+                                "internalType": "bytes32"
+                            },
+                            {
+                                "name": "proof",
+                                "type": "bytes",
+                                "internalType": "bytes"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "postStateItem",
+                        "type": "tuple",
+                        "internalType": "struct LibDA.DAItem",
+                        "components": [
+                            {
+                                "name": "daType",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                            },
+                            {
+                                "name": "dataHash",
+                                "type": "bytes32",
+                                "internalType": "bytes32"
+                            },
+                            {
+                                "name": "proof",
+                                "type": "bytes",
+                                "internalType": "bytes"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "vmProof",
+                        "type": "bytes",
+                        "internalType": "bytes"
+                    }
+                ]
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "subgames",
+        "inputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "version",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "string",
+                "internalType": "string"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "vm",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "vm_",
+                "type": "address",
+                "internalType": "contract IBigStepper"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "weth",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "weth_",
+                "type": "address",
+                "internalType": "contract IDelayedWETH"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "event",
+        "name": "Move",
+        "inputs": [
+            {
+                "name": "parentIndex",
+                "type": "uint256",
+                "indexed": true,
+                "internalType": "uint256"
+            },
+            {
+                "name": "claim",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "Claim"
+            },
+            {
+                "name": "claimant",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Resolved",
+        "inputs": [
+            {
+                "name": "status",
+                "type": "uint8",
+                "indexed": true,
+                "internalType": "enum GameStatus"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "error",
+        "name": "AlreadyInitialized",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "AnchorRootNotFound",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "BlockNumberMatches",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "BondTransferFailed",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "CannotDefendRootClaim",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ClaimAboveSplit",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ClaimAlreadyExists",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ClaimAlreadyResolved",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ClockNotExpired",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ClockTimeExceeded",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ContentLengthMismatch",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "DuplicateStep",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "EmptyItem",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "GameDepthExceeded",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "GameNotInProgress",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "IncorrectBondAmount",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidClockExtension",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidDataRemainder",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidDisputedClaimIndex",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidHeader",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidHeaderRLP",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidLocalIdent",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidOutputRootProof",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidParent",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidPosition",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidPrestate",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidSplitDepth",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "L2BlockNumberChallenged",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "MaxDepthTooLarge",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NoCreditToClaim",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NotSupported",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "OutOfOrderResolution",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "UnexpectedList",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "UnexpectedRootClaim",
+        "inputs": [
+            {
+                "name": "rootClaim",
+                "type": "bytes32",
+                "internalType": "Claim"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "UnexpectedString",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ValidStep",
+        "inputs": []
+    }
+]

--- a/packages/contracts-bedrock/snapshots/abi_loader.go
+++ b/packages/contracts-bedrock/snapshots/abi_loader.go
@@ -13,6 +13,9 @@ var disputeGameFactory []byte
 //go:embed abi/FaultDisputeGame.json
 var faultDisputeGame []byte
 
+//go:embed abi/FaultDisputeGameN.json
+var faultDisputeGameN []byte
+
 //go:embed abi/PreimageOracle.json
 var preimageOracle []byte
 
@@ -27,6 +30,9 @@ func LoadDisputeGameFactoryABI() *abi.ABI {
 }
 func LoadFaultDisputeGameABI() *abi.ABI {
 	return loadABI(faultDisputeGame)
+}
+func LoadFaultDisputeGameNABI() *abi.ABI {
+	return loadABI(faultDisputeGameN)
 }
 func LoadPreimageOracleABI() *abi.ABI {
 	return loadABI(preimageOracle)


### PR DESCRIPTION
## Description
Modify the code in op-challenger2 that calls the FaultDisputeGame contract to call the [FaultDisputeGameN contract](https://github.com/ethstorage/optimism/blob/develop/packages/contracts-bedrock/src/dispute/FaultDisputeGameN.sol) instead.


## Tests
```
cd op-challenger2
go test -v ./game/fault/contracts/
go test -v ./game/fault/types/
```