### PR TITLE
feat(MSFDG): add getSubValues function 

### DIFF
--- a/op-challenger2/game/fault/agent.go
+++ b/op-challenger2/game/fault/agent.go
@@ -30,6 +30,7 @@ type Responder interface {
 
 type ClaimLoader interface {
 	GetAllClaims(ctx context.Context, block rpcblock.Block) ([]types.Claim, error)
+	GetAllClaimsWithSubValues(ctx context.Context) ([]types.Claim, error)
 	IsL2BlockNumberChallenged(ctx context.Context, block rpcblock.Block) (bool, error)
 	GetMaxGameDepth(ctx context.Context) (types.Depth, error)
 	GetSplitDepth(ctx context.Context) (types.Depth, error)
@@ -235,7 +236,7 @@ func (a *Agent) resolveClaims(ctx context.Context) error {
 
 // newGameFromContracts initializes a new game state from the state in the contract
 func (a *Agent) newGameFromContracts(ctx context.Context) (types.Game, error) {
-	claims, err := a.loader.GetAllClaims(ctx, rpcblock.Latest)
+	claims, err := a.loader.GetAllClaimsWithSubValues(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch claims: %w", err)
 	}

--- a/op-challenger2/game/fault/agent_test.go
+++ b/op-challenger2/game/fault/agent_test.go
@@ -221,6 +221,14 @@ func (s *stubClaimLoader) GetAllClaims(_ context.Context, _ rpcblock.Block) ([]t
 	return s.claims, nil
 }
 
+func (s *stubClaimLoader) GetAllClaimsWithSubValues(_ context.Context) ([]types.Claim, error) {
+	s.callCount++
+	if s.callCount > s.maxLoads && s.maxLoads != 0 {
+		return []types.Claim{}, nil
+	}
+	return s.claims, nil
+}
+
 func (s *stubClaimLoader) GetMaxGameDepth(_ context.Context) (types.Depth, error) {
 	return s.maxDepth, nil
 }

--- a/op-challenger2/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger2/game/fault/contracts/faultdisputegame.go
@@ -13,12 +13,15 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger2/game/fault/contracts/metrics"
 	"github.com/ethereum-optimism/optimism/op-challenger2/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger2/game/types"
+	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -58,6 +61,9 @@ var (
 	methodMaxAttackBranch         = "maxAttackBranch"
 	methodAttackV2                = "attackV2"
 	methodStepV2                  = "stepV2"
+	fieldSubValues                = "_claims"
+	fieldAttackBranch             = "_attackBranch"
+	eventMove                     = "Move"
 )
 
 var (
@@ -138,6 +144,23 @@ func mustParseAbi(json []byte) *abi.ABI {
 		panic(err)
 	}
 	return &loaded
+}
+
+func SubValuesHash(values []common.Hash) common.Hash {
+	nelem := len(values)
+	hashes := make([]common.Hash, nelem)
+	copy(hashes, values)
+	for nelem != 1 {
+		for i := 0; i < nelem/2; i++ {
+			hashes[i] = crypto.Keccak256Hash(hashes[i*2][:], hashes[i*2+1][:])
+		}
+		// directly copy the last item
+		if nelem%2 == 1 {
+			hashes[nelem/2] = hashes[nelem-1]
+		}
+		nelem = (nelem + 1) / 2
+	}
+	return hashes[0]
 }
 
 // GetBalance returns the total amount of ETH controlled by this contract.
@@ -447,6 +470,79 @@ func (f *FaultDisputeGameContractLatest) GetAllClaims(ctx context.Context, block
 	return claims, nil
 }
 
+func (f *FaultDisputeGameContractLatest) GetAllClaimsWithSubValues(ctx context.Context) ([]types.Claim, error) {
+	claims, err := f.GetAllClaims(ctx, rpcblock.Latest)
+	if err != nil {
+		return nil, err
+	}
+	for idx, claim := range claims {
+		subValues, attackBranch, err := f.getSubValuesAndAttackBranch(ctx, &claim)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load subValues: %w", err)
+		}
+		claim.SubValues = &subValues
+		claim.AttackBranch = attackBranch
+		claims[idx] = claim
+	}
+	return claims, nil
+}
+
+func (f *FaultDisputeGameContractLatest) getSubValuesAndAttackBranch(ctx context.Context, aggClaim *types.Claim) ([]common.Hash, uint64, error) {
+	defer f.metrics.StartContractRequest("GetSubValues")()
+
+	filter, err := bindings.NewFaultDisputeGameFilterer(f.contract.Addr(), f.multiCaller)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	parentIndex := [...]*big.Int{big.NewInt(int64(aggClaim.ParentContractIndex))}
+	claim := [...][32]byte{aggClaim.ClaimData.ValueBytes()}
+	claimant := [...]common.Address{aggClaim.Claimant}
+	moveIter, err := filter.FilterMove(&bind.FilterOpts{Context: ctx}, parentIndex[:], claim[:], claimant[:])
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to filter move event log: %w", err)
+	}
+	ok := moveIter.Next()
+	if !ok {
+		return nil, 0, fmt.Errorf("failed to get move event log: %w", moveIter.Error())
+	}
+	txHash := moveIter.Event.Raw.TxHash
+
+	getTxByHashCall := batching.NewTxGetByHash(f.contract.Abi(), txHash, methodAttackV2)
+	result, err := f.multiCaller.SingleCall(ctx, rpcblock.Latest, getTxByHashCall)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to load attackV2's calldata: %w", err)
+	}
+
+	txn := result.GetTx()
+	var subValues []common.Hash
+	var attackBranch uint64
+	if len(txn.BlobHashes()) > 0 {
+		// todo: fetch Blobs and unpack it into subValues and attackBranch
+		return nil, 0, fmt.Errorf("blob tx hasn't been supported")
+	} else {
+		inputMap, err := getTxByHashCall.UnpackCallData(&txn)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to unpack tx resp: %w", err)
+		}
+		attackBranchU256 := *abi.ConvertType(inputMap[fieldAttackBranch], new(big.Int)).(*big.Int)
+		attackBranch = attackBranchU256.Uint64()
+
+		maxAttackBranch, err := f.GetMaxAttackBranch(ctx)
+		if err != nil {
+			return nil, 0, err
+		}
+		valuesBytesLen := uint(32 * maxAttackBranch)
+		bytes := abi.ConvertType(inputMap[fieldSubValues], make([]byte, valuesBytesLen)).([]byte)
+		for i := uint64(0); i < maxAttackBranch; i++ {
+			hash := common.BytesToHash(bytes[i*32 : (i+1)*32])
+			subValues = append(subValues, hash)
+		}
+	}
+
+	return subValues, attackBranch, nil
+}
+
 func (f *FaultDisputeGameContractLatest) IsResolved(ctx context.Context, block rpcblock.Block, claims ...types.Claim) ([]bool, error) {
 	defer f.metrics.StartContractRequest("IsResolved")()
 	calls := make([]batching.Call, 0, len(claims))
@@ -670,4 +766,5 @@ type FaultDisputeGameContract interface {
 	StepV2Tx(claimIdx uint64, attackBranch uint64, stateData []byte, proof types.StepProof) (txmgr.TxCandidate, error)
 	GetNBits(ctx context.Context) (uint64, error)
 	GetMaxAttackBranch(ctx context.Context) (uint64, error)
+	GetAllClaimsWithSubValues(ctx context.Context) ([]types.Claim, error)
 }

--- a/op-challenger2/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger2/game/fault/contracts/faultdisputegame_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	coreTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/require"
 )
@@ -849,5 +851,129 @@ func TestStepV2Tx(t *testing.T) {
 			require.NoError(t, err)
 			stubRpc.VerifyTxCandidate(tx)
 		})
+	}
+}
+
+func TestGetAllClaimsWithSubValues(t *testing.T) {
+	for _, version := range versions {
+		t.Run(version.version, func(t *testing.T) {
+			stubRpc, game := setupFaultDisputeGameTest(t, version)
+			block := rpcblock.Latest
+
+			claimant := common.Address{0xbb}
+			bond := big.NewInt(1044)
+			nBits := uint64(2)
+			claimsBytes := make([]byte, ((1<<nBits)-1)*32)
+			subValues := []common.Hash{{0x10}, {0x11}, {0x12}}
+			for i := range claimsBytes {
+				claimsBytes[i] = subValues[i/32][i%32]
+			}
+			daType := faultTypes.CallDataType
+			parentPos := faultTypes.NewPosition(0, big.NewInt(0))
+			// attackBranch must be 0, because we can only attach the first branch of rootClaim
+			attackBranch := big.NewInt(0)
+			parent := faultTypes.Claim{ClaimData: faultTypes.ClaimData{Value: common.Hash{0xbb}, Position: parentPos}, ContractIndex: 111}
+			stubRpc.SetResponse(fdgAddr, methodNBits, block, nil, []interface{}{new(big.Int).SetUint64(nBits)})
+			stubRpc.SetResponse(fdgAddr, methodRequiredBond, block, []interface{}{parent.Position.MoveN(nBits, attackBranch.Uint64()).ToGIndex()}, []interface{}{bond})
+			stubRpc.SetResponse(fdgAddr, methodAttackV2, block, []interface{}{parent.Value, big.NewInt(111), attackBranch, daType, claimsBytes[:]}, nil)
+			txCandidate, err := game.AttackV2Tx(context.Background(), parent, attackBranch.Uint64(), daType.Uint64(), claimsBytes[:])
+			require.NoError(t, err)
+			tx := coreTypes.NewTx(&coreTypes.LegacyTx{
+				Nonce:    0,
+				GasPrice: big.NewInt(11111),
+				Gas:      1111,
+				To:       &claimant,
+				Value:    big.NewInt(111),
+				Data:     txCandidate.TxData,
+			})
+			packed, err := tx.MarshalBinary()
+			require.NoError(t, err)
+			txHash := tx.Hash()
+			stubRpc.SetGetTxByHashResponse(txHash, packed)
+
+			// mock eventLog
+			eventName := eventMove
+			fdgAbi := version.loadAbi()
+			challgenIndex := []interface{}{big.NewInt(int64(parent.ContractIndex))}
+			claim := []interface{}{SubValuesHash(subValues)}
+			address := []interface{}{claimant}
+			query := [][]interface{}{challgenIndex, claim, address}
+
+			query = append([][]interface{}{{fdgAbi.Events[eventName].ID}}, query...)
+			topics, err := abi.MakeTopics(query...)
+			require.NoError(t, err)
+			var queryTopics []common.Hash
+			for _, item := range topics {
+				queryTopics = append(queryTopics, item[0])
+			}
+			out := []coreTypes.Log{
+				{
+					Address: fdgAddr,
+					Topics:  queryTopics,
+					Data:    []byte{},
+					TxHash:  txHash,
+				},
+			}
+
+			stubRpc.SetFilterLogResponse(topics, fdgAddr, block, out)
+			stubRpc.SetResponse(fdgAddr, methodClaimCount, block, nil, []interface{}{big.NewInt(1)})
+			stubRpc.SetResponse(fdgAddr, methodMaxAttackBranch, block, nil, []interface{}{big.NewInt(1<<nBits - 1)})
+			claim0 := faultTypes.Claim{
+				ClaimData: faultTypes.ClaimData{
+					Value:    SubValuesHash(subValues),
+					Position: parent.Position.MoveN(nBits, attackBranch.Uint64()),
+					Bond:     bond,
+				},
+				CounteredBy: common.Address{0x00},
+				Claimant:    claimant,
+				Clock:       decodeClock(big.NewInt(1234)),
+				// contractIndex is mocked to 0, because there is only one claim for GetAllClaimsWithSubValues
+				ContractIndex:       0,
+				ParentContractIndex: parent.ContractIndex,
+				SubValues:           &subValues,
+				AttackBranch:        attackBranch.Uint64(),
+			}
+			expectedClaims := []faultTypes.Claim{claim0}
+			for _, claim := range expectedClaims {
+				expectGetClaim(stubRpc, block, claim)
+			}
+
+			claims, err := game.GetAllClaimsWithSubValues(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, 1, len(claims))
+			require.Equal(t, claim0.SubValues, claims[0].SubValues)
+			claim0.SubValues = nil
+			claims[0].SubValues = nil
+			require.Equal(t, 0, claim0.ClaimData.IndexAtDepth().Cmp(claims[0].ClaimData.IndexAtDepth()))
+			claim0.ClaimData = faultTypes.ClaimData{}
+			claims[0].ClaimData = faultTypes.ClaimData{}
+			require.Equal(t, claim0, claims[0])
+		})
+	}
+}
+
+func TestSubValuesHash(t *testing.T) {
+	allClaims := [][]common.Hash{
+		{{0x01}, {0x02}, {0x03}},
+		{{0x01}, {0x02}, {0x03}, {0x04}},
+	}
+	Hash := crypto.Keccak256Hash
+	tests := []struct {
+		claims       []common.Hash
+		expectedHash common.Hash
+	}{
+		{
+			claims:       allClaims[0],
+			expectedHash: Hash(Hash(allClaims[0][0][:], allClaims[0][1][:]).Bytes(), allClaims[0][2][:]),
+		},
+		{
+			claims:       allClaims[1],
+			expectedHash: Hash(Hash(allClaims[1][0][:], allClaims[1][1][:]).Bytes(), Hash(allClaims[1][2][:], allClaims[1][3][:]).Bytes()),
+		},
+	}
+
+	for _, test := range tests {
+		actualHash := SubValuesHash(test.claims)
+		require.Equal(t, test.expectedHash, actualHash)
 	}
 }

--- a/op-challenger2/game/fault/types/position.go
+++ b/op-challenger2/game/fault/types/position.go
@@ -162,7 +162,7 @@ func bigMSB(x *big.Int) Depth {
 func (p Position) MoveN(nbits uint64, attackingBranch uint64) Position {
 	return Position{
 		depth:        p.depth + Depth(nbits),
-		indexAtDepth: new(big.Int).Lsh(new(big.Int).Add(p.indexAtDepth, big.NewInt(int64(attackingBranch))), uint(nbits)),
+		indexAtDepth: new(big.Int).Lsh(new(big.Int).Add(p.IndexAtDepth(), big.NewInt(int64(attackingBranch))), uint(nbits)),
 	}
 }
 

--- a/op-service/sources/batching/bound.go
+++ b/op-service/sources/batching/bound.go
@@ -32,6 +32,10 @@ func (b *BoundContract) Addr() common.Address {
 	return b.addr
 }
 
+func (b *BoundContract) Abi() *abi.ABI {
+	return b.abi
+}
+
 func (b *BoundContract) Call(method string, args ...interface{}) *ContractCall {
 	return NewContractCall(b.abi, b.addr, method, args...)
 }

--- a/op-service/sources/batching/call.go
+++ b/op-service/sources/batching/call.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -66,4 +67,8 @@ func (c *CallResult) GetBytes32Slice(i int) [][32]byte {
 
 func (c *CallResult) GetString(i int) string {
 	return *abi.ConvertType(c.out[i], new(string)).(*string)
+}
+
+func (c *CallResult) GetTx() types.Transaction {
+	return *abi.ConvertType(c.out[0], new(types.Transaction)).(*types.Transaction)
 }

--- a/op-service/sources/batching/event_call.go
+++ b/op-service/sources/batching/event_call.go
@@ -1,0 +1,37 @@
+package batching
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type EventCall struct {
+	topics [][]common.Hash
+	to     []common.Address
+}
+
+func NewEventCall(q ethereum.FilterQuery) *EventCall {
+	return &EventCall{
+		topics: q.Topics,
+		to:     q.Addresses,
+	}
+}
+
+func (b *EventCall) ToBatchElemCreator() (BatchElementCreator, error) {
+	return func(block rpcblock.Block) (any, rpc.BatchElem) {
+		out := new([]types.Log)
+		return out, rpc.BatchElem{
+			Method: "eth_getFilterLogs",
+			Args:   []interface{}{b.topics, b.to[0], block.ArgValue()},
+			Result: &out,
+		}
+	}, nil
+}
+
+func (c *EventCall) HandleResult(result interface{}) (*CallResult, error) {
+	res := result.(*[]types.Log)
+	return &CallResult{out: []interface{}{*res}}, nil
+}

--- a/op-service/sources/batching/event_call_test.go
+++ b/op-service/sources/batching/event_call_test.go
@@ -1,0 +1,75 @@
+package batching
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventLogFilter(t *testing.T) {
+	addr := common.Address{0xbd}
+	stub := batchingTest.NewRpcStub(t)
+	owner := []common.Address{{0xaa}}
+	spender := []common.Address{{0xbb}}
+
+	testAbi, err := batchingTest.ERC20MetaData.GetAbi()
+	require.NoError(t, err)
+	name := "Approval"
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+	var spenderRule []interface{}
+	for _, spenderItem := range spender {
+		spenderRule = append(spenderRule, spenderItem)
+	}
+	query := [][]interface{}{ownerRule, spenderRule}
+	query = append([][]interface{}{{testAbi.Events[name].ID}}, query...)
+
+	topics, err := abi.MakeTopics(query...)
+	require.NoError(t, err)
+
+	txHash := common.Hash{0x11}
+	block := rpcblock.Latest
+	require.NoError(t, err)
+	event := testAbi.Events[name]
+	inputs := event.Inputs
+
+	amount := big.NewInt(3)
+	packedData, err := inputs.NonIndexed().Pack(amount)
+	require.NoError(t, err)
+	_out := []types.Log{
+		{
+			Address: addr,
+			Topics:  []common.Hash{topics[0][0], topics[1][0], topics[2][0]},
+			Data:    packedData,
+			TxHash:  txHash,
+		},
+	}
+	out := make([]interface{}, len(_out))
+	for i, r := range _out {
+		out[i] = r
+	}
+
+	stub.SetFilterLogResponse(topics, addr, block, _out)
+	caller := NewMultiCaller(stub, DefaultBatchSize)
+
+	filter, err := batchingTest.NewERC20Filterer(addr, caller)
+	require.NoError(t, err)
+
+	iterator, err := filter.FilterApproval(nil, owner, spender)
+	require.NoError(t, err)
+
+	res := iterator.Next()
+	require.True(t, res, iterator.Error())
+	require.Equal(t, _out[0].Address, iterator.Event.Raw.Address)
+	require.Equal(t, _out[0].Topics, iterator.Event.Raw.Topics)
+	require.Equal(t, _out[0].Data, iterator.Event.Raw.Data)
+	require.Equal(t, txHash, iterator.Event.Raw.TxHash)
+}

--- a/op-service/sources/batching/multicall.go
+++ b/op-service/sources/batching/multicall.go
@@ -2,10 +2,13 @@ package batching
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -79,4 +82,21 @@ func (m *MultiCaller) Call(ctx context.Context, block rpcblock.Block, calls ...C
 		callResults[i] = out
 	}
 	return callResults, nil
+}
+
+// implement LogFilterer interface
+func (m *MultiCaller) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	call := NewEventCall(q)
+	results, err := m.SingleCall(ctx, rpcblock.ByNumber(q.FromBlock.Uint64()), call)
+	if err != nil {
+		return nil, err
+	}
+	var out []types.Log
+	results.GetStruct(0, &out)
+	return out, nil
+}
+
+// implement LogFilterer interface
+func (m *MultiCaller) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	return nil, errors.New("unimplemented")
 }

--- a/op-service/sources/batching/test/abi_stub.go
+++ b/op-service/sources/batching/test/abi_stub.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -146,6 +147,26 @@ func (l *AbiBasedRpc) SetResponse(to common.Address, method string, block rpcblo
 		packedArgs: packedArgs,
 		outputs:    output,
 	})
+}
+
+func (l *AbiBasedRpc) SetFilterLogResponse(topics [][]common.Hash, to common.Address, block rpcblock.Block, output []types.Log) {
+	if output == nil {
+		output = []types.Log{}
+	}
+
+	l.AddExpectedCall(&expectedFilterLogsCall{
+		topics:  topics,
+		to:      to,
+		block:   block,
+		outputs: output,
+	})
+}
+
+func (l *AbiBasedRpc) SetGetTxByHashResponse(txHash common.Hash, output []byte) {
+	if output == nil {
+		output = []byte{}
+	}
+	l.AddExpectedCall(&expectedGetTxByHashCall{txHash: txHash, outputs: output})
 }
 
 func (l *AbiBasedRpc) VerifyTxCandidate(candidate txmgr.TxCandidate) {

--- a/op-service/sources/batching/test/event_stub.go
+++ b/op-service/sources/batching/test/event_stub.go
@@ -1,0 +1,66 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+type expectedFilterLogsCall struct {
+	topics  [][]common.Hash
+	to      common.Address
+	block   rpcblock.Block
+	outputs []types.Log
+	err     error
+}
+
+func (c *expectedFilterLogsCall) Matches(rpcMethod string, args ...interface{}) error {
+	if rpcMethod != "eth_getFilterLogs" {
+		return fmt.Errorf("expected rpcMethod eth_getFilterLogs but was %v", rpcMethod)
+	}
+
+	topics, ok := args[0].([][]common.Hash)
+	if !ok {
+		return fmt.Errorf("arg 0 is not [][]common.Hash")
+	}
+
+	if !reflect.DeepEqual(topics, c.topics) {
+		return fmt.Errorf("expected topics %v but was %v", c.topics, topics)
+	}
+
+	to := args[1].(common.Address)
+	if to != c.to {
+		return fmt.Errorf("expected contract address %v but was %v", c.to, to)
+	}
+	return c.err
+}
+
+func (c *expectedFilterLogsCall) Execute(t *testing.T, out interface{}) error {
+	j, err := json.Marshal(c.outputs)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(j, out))
+	return c.err
+}
+
+func (c *expectedFilterLogsCall) String() string {
+	return fmt.Sprintf("{to: %v, block: %v, outputs: %v}", c.to, c.block, c.outputs)
+}
+
+func (l *RpcStub) SetFilterLogResponse(topics [][]common.Hash, to common.Address, block rpcblock.Block, output []types.Log) {
+	if output == nil {
+		output = []types.Log{}
+	}
+
+	l.AddExpectedCall(&expectedFilterLogsCall{
+		topics:  topics,
+		to:      to,
+		block:   block,
+		outputs: output,
+	})
+}

--- a/op-service/sources/batching/test/generic_stub.go
+++ b/op-service/sources/batching/test/generic_stub.go
@@ -80,6 +80,14 @@ func NewGetBalanceCall(addr common.Address, block rpcblock.Block, balance *big.I
 	}
 }
 
+func NewGetTxCall(txHash common.Hash, block rpcblock.Block, out *[]byte) ExpectedRpcCall {
+	return &GenericExpectedCall{
+		method: "eth_getTransactionByHash",
+		args:   []interface{}{txHash, block.ArgValue()},
+		result: hexutil.Encode(*out),
+	}
+}
+
 func (c *GenericExpectedCall) Matches(rpcMethod string, args ...interface{}) error {
 	if rpcMethod != c.method {
 		return fmt.Errorf("expected method %v but was %v", c.method, rpcMethod)

--- a/op-service/sources/batching/test/tx_stub.go
+++ b/op-service/sources/batching/test/tx_stub.go
@@ -1,0 +1,45 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+)
+
+type expectedGetTxByHashCall struct {
+	txHash  common.Hash
+	outputs []byte
+	err     error
+}
+
+func (c *expectedGetTxByHashCall) Matches(rpcMethod string, args ...interface{}) error {
+	if rpcMethod != "eth_getTransactionByHash" {
+		return fmt.Errorf("expected rpcMethod eth_getTransactionByHash but was %v", rpcMethod)
+	}
+
+	txhash, ok := args[0].(common.Hash)
+	if !ok {
+		return fmt.Errorf("arg 0 is not common.Hash")
+	}
+
+	if txhash != c.txHash {
+		return fmt.Errorf("expected txHash %v but was %v", c.txHash, txhash)
+	}
+
+	return c.err
+}
+
+func (c *expectedGetTxByHashCall) Execute(t *testing.T, out interface{}) error {
+	j, err := json.Marshal(hexutil.Bytes(c.outputs))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(j, out))
+	return c.err
+}
+
+func (c *expectedGetTxByHashCall) String() string {
+	return fmt.Sprintf("{txHash: %v, outputs: %v}", c.txHash, c.outputs)
+}

--- a/op-service/sources/batching/tx_call.go
+++ b/op-service/sources/batching/tx_call.go
@@ -1,0 +1,64 @@
+package batching
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type TxGetByHashCall struct {
+	Abi    *abi.ABI
+	TxHash common.Hash
+	Method string
+}
+
+func NewTxGetByHash(abi *abi.ABI, txhash common.Hash, method string) *TxGetByHashCall {
+	return &TxGetByHashCall{
+		Abi:    abi,
+		TxHash: txhash,
+		Method: method,
+	}
+}
+
+func (b *TxGetByHashCall) ToBatchElemCreator() (BatchElementCreator, error) {
+	return func(block rpcblock.Block) (any, rpc.BatchElem) {
+		out := new(hexutil.Bytes)
+		return out, rpc.BatchElem{
+			Method: "eth_getTransactionByHash",
+			Args:   []interface{}{b.TxHash, block.ArgValue()},
+			Result: &out,
+		}
+	}, nil
+}
+
+func (c *TxGetByHashCall) HandleResult(result interface{}) (*CallResult, error) {
+	res, ok := result.(*hexutil.Bytes)
+	if !ok {
+		return nil, fmt.Errorf("result is not hexutil.Bytes")
+	}
+
+	txn := new(types.Transaction)
+	err := txn.UnmarshalBinary(*res)
+	if err != nil {
+		return nil, err
+	}
+	return &CallResult{out: []interface{}{txn}}, nil
+}
+
+func (c *TxGetByHashCall) UnpackCallData(txn *types.Transaction) (map[string]interface{}, error) {
+	data := txn.Data()
+	m, err := c.Abi.MethodById(data[:4])
+	v := map[string]interface{}{}
+	if err != nil {
+		return map[string]interface{}{}, err
+	}
+	if err := m.Inputs.UnpackIntoMap(v, data[4:]); err != nil {
+		return map[string]interface{}{}, err
+	}
+	return v, nil
+}

--- a/op-service/sources/batching/tx_call_test.go
+++ b/op-service/sources/batching/tx_call_test.go
@@ -1,0 +1,50 @@
+package batching
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnpackTxCalldata(t *testing.T) {
+	expectedSpender := common.Address{0xcc}
+	expectedAmount := big.NewInt(1234444)
+	txHash := common.Hash{0x11}
+	addr := common.Address{0xbd}
+
+	testAbi, err := test.ERC20MetaData.GetAbi()
+	require.NoError(t, err)
+	contractCall := NewContractCall(testAbi, addr, "approve", expectedSpender, expectedAmount)
+	inputData, err := contractCall.Pack()
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    0,
+		GasPrice: big.NewInt(11111),
+		Gas:      1111,
+		To:       &addr,
+		Value:    big.NewInt(111),
+		Data:     inputData,
+	})
+	require.NoError(t, err)
+	packed, err := tx.MarshalBinary()
+	require.NoError(t, err)
+
+	stub := test.NewRpcStub(t)
+	stub.AddExpectedCall(test.NewGetTxCall(txHash, rpcblock.Latest, &packed))
+
+	caller := NewMultiCaller(stub, DefaultBatchSize)
+	txCall := NewTxGetByHash(testAbi, txHash, "approve")
+	result, err := caller.SingleCall(context.Background(), rpcblock.Latest, txCall)
+	require.NoError(t, err)
+
+	decodedTx := result.GetTx()
+	unpackedMap, err := txCall.UnpackCallData(&decodedTx)
+	require.NoError(t, err)
+	require.Equal(t, expectedSpender, unpackedMap["spender"])
+	require.Equal(t, expectedAmount, unpackedMap["amount"])
+}


### PR DESCRIPTION
## Description
This PR adds a `getSubValues` function that retrieves the `_claims` and `_attackBranch` fields. These values provide essential preimages for determining the next attack action by comparing them with the local trace's  `_claims`.

## Tests
`go test  ./...`