### PR TITLE
fix "just build"

### DIFF
--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -88,7 +88,7 @@ contract L1Block is ISemver, IGasToken {
     }
 
     /// @notice size of historyHashes.
-    uint256 public constant HISTORY_SIZE = 8192;
+    uint256 internal constant HISTORY_SIZE = 8192;
     /// @notice The 8191 history L1 blockhashes and 1 latest L1 blockhash.
     bytes32[HISTORY_SIZE] internal historyHashes;
 
@@ -206,5 +206,10 @@ contract L1Block is ISemver, IGasToken {
         GasPayingToken.set({ _token: _token, _decimals: _decimals, _name: _name, _symbol: _symbol });
 
         emit GasPayingTokenSet({ token: _token, decimals: _decimals, name: _name, symbol: _symbol });
+    }
+
+    /// @notice Returns the size of history hashes.
+    function historySize() external view returns (uint256) {
+        return HISTORY_SIZE;
     }
 }

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -90,7 +90,7 @@ contract L1Block is ISemver, IGasToken {
     /// @notice size of historyHashes.
     uint256 public constant HISTORY_SIZE = 8192;
     /// @notice The 8191 history L1 blockhashes and 1 latest L1 blockhash.
-    bytes32[HISTORY_SIZE] public historyHashes;
+    bytes32[HISTORY_SIZE] internal historyHashes;
 
     /// @custom:legacy
     /// @notice Updates the L1 block values.

--- a/packages/contracts-bedrock/src/L2/interfaces/IL1Block.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IL1Block.sol
@@ -38,4 +38,7 @@ interface IL1Block {
     function version() external pure returns (string memory);
 
     function __constructor__() external;
+
+    function HISTORY_SIZE() external view returns (uint256);
+    function blockHash(uint256 _historyNumber) external view returns (bytes32);
 }

--- a/packages/contracts-bedrock/src/L2/interfaces/IL1Block.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IL1Block.sol
@@ -39,6 +39,6 @@ interface IL1Block {
 
     function __constructor__() external;
 
-    function HISTORY_SIZE() external view returns (uint256);
+    function historySize() external view returns (uint256);
     function blockHash(uint256 _historyNumber) external view returns (bytes32);
 }

--- a/packages/contracts-bedrock/src/L2/interfaces/IL1BlockInterop.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IL1BlockInterop.sol
@@ -58,6 +58,6 @@ interface IL1BlockInterop {
 
     function __constructor__() external;
 
-    function HISTORY_SIZE() external view returns (uint256);
+    function historySize() external view returns (uint256);
     function blockHash(uint256 _historyNumber) external view returns (bytes32);
 }

--- a/packages/contracts-bedrock/src/L2/interfaces/IL1BlockInterop.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IL1BlockInterop.sol
@@ -57,4 +57,7 @@ interface IL1BlockInterop {
     function version() external pure returns (string memory);
 
     function __constructor__() external;
+
+    function HISTORY_SIZE() external view returns (uint256);
+    function blockHash(uint256 _historyNumber) external view returns (bytes32);
 }

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -179,14 +179,14 @@ contract L1BlockEcotone_Test is L1BlockTest {
     )
         external
     {
-        if (number > type(uint64).max - uint64(l1Block.HISTORY_SIZE()) - 1) {
-            number = type(uint64).max - uint64(l1Block.HISTORY_SIZE()) - 1;
+        if (number > type(uint64).max - uint64(l1Block.historySize()) - 1) {
+            number = type(uint64).max - uint64(l1Block.historySize()) - 1;
         }
-        if (uint256(hash) > type(uint256).max - l1Block.HISTORY_SIZE() - 1) {
-            hash = bytes32(type(uint256).max - l1Block.HISTORY_SIZE() - 1);
+        if (uint256(hash) > type(uint256).max - l1Block.historySize() - 1) {
+            hash = bytes32(type(uint256).max - l1Block.historySize() - 1);
         }
 
-        for (uint256 i = 1; i <= l1Block.HISTORY_SIZE() + 1; i++) {
+        for (uint256 i = 1; i <= l1Block.historySize() + 1; i++) {
             bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesEcotone(
                 baseFeeScalar,
                 blobBaseFeeScalar,
@@ -208,11 +208,11 @@ contract L1BlockEcotone_Test is L1BlockTest {
         }
 
         assertTrue(
-            l1Block.blockHash(number + l1Block.HISTORY_SIZE() + 1) == bytes32(0),
+            l1Block.blockHash(number + l1Block.historySize() + 1) == bytes32(0),
             "should return bytes32(0) for the latest L1 block"
         );
         assertTrue(l1Block.blockHash(number + 1) == bytes32(0), "should return bytes32(0) for blocks out of range");
-        for (uint256 i = 2; i <= l1Block.HISTORY_SIZE(); i++) {
+        for (uint256 i = 2; i <= l1Block.historySize(); i++) {
             assertTrue(
                 l1Block.blockHash(number + i) == bytes32(uint256(hash) + i),
                 "blockHash's return value should match the value set"


### PR DESCRIPTION
Currently when you build contracts with `just build`, it'll run `go run ./scripts/checks/interfaces` which check consistency between interface and implementation.

It'll error out like this:

<img width="1665" alt="image" src="https://github.com/user-attachments/assets/a551f347-ea02-42a9-a288-4b54e01ab6cc">

This PR adds public functions from L1Block to IL1Block so that the check can pass.