### PR TITLE
fix `just build` warning and last error

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/interfaces/main.go
+++ b/packages/contracts-bedrock/scripts/checks/interfaces/main.go
@@ -29,6 +29,7 @@ var excludeContracts = []string{
 	"IInitializable", "ILegacyMintableERC20", "IOptimismMintableERC20",
 	"IOptimismMintableERC721", "KontrolCheatsBase", "IWETH", "IDelayedWETH", "ISuperchainWETH",
 	"IL2ToL2CrossDomainMessenger", "ICrossL2Inbox", "ISystemConfigInterop", "IResolvedDelegateProxy",
+	"IERC20Upgradeable",
 }
 
 type ContractDefinition struct {

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -209,7 +209,7 @@ contract L1Block is ISemver, IGasToken {
     }
 
     /// @notice Returns the size of history hashes.
-    function historySize() external view returns (uint256) {
+    function historySize() external pure returns (uint256) {
         return HISTORY_SIZE;
     }
 }

--- a/packages/contracts-bedrock/src/L2/interfaces/IL1Block.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IL1Block.sol
@@ -39,6 +39,6 @@ interface IL1Block {
 
     function __constructor__() external;
 
-    function historySize() external view returns (uint256);
+    function historySize() external pure returns (uint256);
     function blockHash(uint256 _historyNumber) external view returns (bytes32);
 }

--- a/packages/contracts-bedrock/src/L2/interfaces/IL1BlockInterop.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IL1BlockInterop.sol
@@ -58,6 +58,6 @@ interface IL1BlockInterop {
 
     function __constructor__() external;
 
-    function historySize() external view returns (uint256);
+    function historySize() external pure returns (uint256);
     function blockHash(uint256 _historyNumber) external view returns (bytes32);
 }


### PR DESCRIPTION
This PR fixes the warning below:

<img width="598" alt="image" src="https://github.com/user-attachments/assets/a6e7cac4-1ecc-469f-8be0-39f9587ad7a3">

and the error below:

<img width="599" alt="image" src="https://github.com/user-attachments/assets/38e97882-3e30-4d8d-a948-2d011eb61350">

This error is caused by `SoulGasToken` which inherits from `ERC20Upgradeable`.

After this, `just build` passes with no error.