### PR TITLE
add allowSgtValue/disallowSgtValue to SGT contract

### DIFF
--- a/op-e2e/opgeth/op_geth_test.go
+++ b/op-e2e/opgeth/op_geth_test.go
@@ -1006,7 +1006,7 @@ func TestEcotone(t *testing.T) {
 }
 
 func TestSoulGasToken(t *testing.T) {
-	SoulGasTokenABI, err := util.ParseFunctionsAsABI([]string{"function deposit()"})
+	SoulGasTokenABI, err := util.ParseFunctionsAsABI([]string{"function deposit()", "function allowSgtValue(address[] contracts)"})
 	require.NoError(t, err)
 	t.Run("no SoulGasToken", func(t *testing.T) {
 		op_e2e.InitParallel(t)
@@ -1307,6 +1307,76 @@ func TestSoulGasToken(t *testing.T) {
 			Gas:       1_000_001,
 			To:        &cfg.Secrets.Addresses().Alice,
 			Value:     big.NewInt(params.Wei),
+			Data:      nil,
+		})
+		_, err = opGeth.AddL2Block(ctx, tx)
+		require.NoError(t, err)
+	})
+
+	t.Run("sgt as msg.value", func(t *testing.T) {
+		op_e2e.InitParallel(t)
+		cfg := e2esys.DefaultSystemConfigForSoulGasToken(t, true, true)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		opGeth, err := NewOpGeth(t, ctx, &cfg)
+		require.NoError(t, err)
+		defer opGeth.Close()
+
+		// mint enough SoulGasToken with deposit tx, but no native balance
+		targetPK, _ := crypto.GenerateKey()
+		targetAccount := crypto.PubkeyToAddress(*targetPK.Public().(*ecdsa.PublicKey))
+
+		// fund targetAccount with 1 eth + 1wei
+		transferEthTx := types.NewTx(&types.DepositTx{
+			From:  cfg.Secrets.Addresses().Bob,
+			To:    &targetAccount,
+			Value: big.NewInt(params.Ether + params.Wei),
+			Gas:   1000001,
+		})
+		// convert 1 eth to sgt for targetAccount
+		mintTx := types.NewTx(&types.DepositTx{
+			From:  targetAccount,
+			To:    &types.SoulGasTokenAddr,
+			Value: big.NewInt(params.Ether),
+			Gas:   1000001,
+			Data:  SoulGasTokenABI.Methods["deposit"].ID,
+		})
+		// set alice as whitelist for sgt
+		inputData, err := SoulGasTokenABI.Pack("allowSgtValue", []common.Address{cfg.Secrets.Addresses().Alice})
+		require.NoError(t, err)
+		whitelistTx := types.NewTx(&types.DepositTx{
+			From:  cfg.DeployConfig.ProxyAdminOwner,
+			To:    &types.SoulGasTokenAddr,
+			Value: big.NewInt(0),
+			Gas:   1000001,
+			Data:  inputData,
+		})
+		_, err = opGeth.AddL2Block(ctx, transferEthTx, mintTx, whitelistTx)
+		require.NoError(t, err)
+
+		// ensure mintTx is successful
+		receipt, err := opGeth.L2Client.TransactionReceipt(ctx, mintTx.Hash())
+		require.NoError(t, err)
+		assert.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+		// ensure whitelistTx is successful
+		receipt, err = opGeth.L2Client.TransactionReceipt(ctx, whitelistTx.Hash())
+		require.NoError(t, err)
+		assert.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+		signer := types.LatestSigner(opGeth.L2ChainConfig)
+
+		// send 0.1 eth to alice
+		tx := types.MustSignNewTx(targetPK, signer, &types.DynamicFeeTx{
+			ChainID:   big.NewInt(int64(cfg.DeployConfig.L2ChainID)),
+			Nonce:     1,
+			GasTipCap: big.NewInt(100),
+			GasFeeCap: big.NewInt(100000),
+			Gas:       1_000_001,
+			To:        &cfg.Secrets.Addresses().Alice,
+			Value:     big.NewInt(params.Ether * 0.1),
 			Data:      nil,
 		})
 		_, err = opGeth.AddL2Block(ctx, tx)

--- a/packages/contracts-bedrock/src/L2/SoulGasToken.sol
+++ b/packages/contracts-bedrock/src/L2/SoulGasToken.sol
@@ -19,10 +19,17 @@ contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
         mapping(address => bool) _minters;
         // _burners are whitelist EOAs to burn/withdraw SoulGasToken
         mapping(address => bool) _burners;
-        // _allow_sgt_value are whitelist contracts to consume sgt as msg.value
+        // _allowSgtValue are whitelist contracts to consume sgt as msg.value
         // when IS_BACKED_BY_NATIVE
-        mapping(address => bool) _allow_sgt_value;
+        mapping(address => bool) _allowSgtValue;
     }
+
+    /// @notice Emitted when sgt as msg.value is enabled for a contract.
+    /// @param from     Address of the contract for which sgt as msg.value is enabled.
+    event AllowSgtValue(address indexed from);
+    /// @notice Emitted when sgt as msg.value is disabled for a contract.
+    /// @param from     Address of the contract for which sgt as msg.value is disabled.
+    event DisallowSgtValue(address indexed from);
 
     // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.SoulGasToken")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant _SOULGASTOKEN_STORAGE_LOCATION =
@@ -160,7 +167,8 @@ contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
         SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
         uint256 i;
         for (i = 0; i < contracts.length; i++) {
-            $._allow_sgt_value[contracts[i]] = true;
+            $._allowSgtValue[contracts[i]] = true;
+            emit AllowSgtValue(contracts[i]);
         }
     }
 
@@ -170,7 +178,8 @@ contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
         SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
         uint256 i;
         for (i = 0; i < contracts.length; i++) {
-            $._allow_sgt_value[contracts[i]] = false;
+            $._allowSgtValue[contracts[i]] = false;
+            emit DisallowSgtValue(contracts[i]);
         }
     }
 

--- a/packages/contracts-bedrock/src/L2/SoulGasToken.sol
+++ b/packages/contracts-bedrock/src/L2/SoulGasToken.sol
@@ -15,10 +15,13 @@ import { Constants } from "src/libraries/Constants.sol";
 contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
     /// @custom:storage-location erc7201:openzeppelin.storage.SoulGasToken
     struct SoulGasTokenStorage {
-        // _minters are be whitelist EOAs, only used when !IS_BACKED_BY_NATIVE
+        // _minters are whitelist EOAs, only used when !IS_BACKED_BY_NATIVE
         mapping(address => bool) _minters;
         // _burners are whitelist EOAs to burn/withdraw SoulGasToken
         mapping(address => bool) _burners;
+        // _allow_sgt_value are whitelist contracts to consume sgt as msg.value
+        // when IS_BACKED_BY_NATIVE
+        mapping(address => bool) _allow_sgt_value;
     }
 
     // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.SoulGasToken")) - 1)) & ~bytes32(uint256(0xff))
@@ -148,6 +151,26 @@ contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
         uint256 i;
         for (i = 0; i < burners_.length; i++) {
             delete $._burners[burners_[i]];
+        }
+    }
+
+    /// @notice allowSgtValue is called by the owner to enable whitelist contracts to consume sgt as msg.value
+    function allowSgtValue(address[] calldata contracts) external onlyOwner {
+        require(IS_BACKED_BY_NATIVE, "allowSgtValue should only be called when IS_BACKED_BY_NATIVE");
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        uint256 i;
+        for (i = 0; i < contracts.length; i++) {
+            $._allow_sgt_value[contracts[i]] = true;
+        }
+    }
+
+    /// @notice allowSgtValue is called by the owner to disable whitelist contracts to consume sgt as msg.value
+    function disallowSgtValue(address[] calldata contracts) external onlyOwner {
+        require(IS_BACKED_BY_NATIVE, "disallowSgtValue should only be called when IS_BACKED_BY_NATIVE");
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        uint256 i;
+        for (i = 0; i < contracts.length; i++) {
+            $._allow_sgt_value[contracts[i]] = false;
         }
     }
 


### PR DESCRIPTION
This PR prepares `SoulGasToken` contract so that if:
1. `IS_BACKED_BY_NATIVE` is true
2. a whitelisted contract is used as `tx.to`


 then `SoulGasToken` balance can be used as `msg.value`.