### PR TITLE
Fix ./test/vendor/Initializable.t.sol test

### DIFF
--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -62,7 +62,5 @@
   "daChallengeWindow": 100,
   "daResolveWindow": 100,
   "daBondSize": 1000,
-  "daResolverRefundPercentage": 50,
-  "useSoulGasToken": true,
-  "isSoulBackedByNative": true
+  "daResolverRefundPercentage": 50
 }

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -62,5 +62,7 @@
   "daChallengeWindow": 100,
   "daResolveWindow": 100,
   "daBondSize": 1000,
-  "daResolverRefundPercentage": 50
+  "daResolverRefundPercentage": 50,
+  "useSoulGasToken": true,
+  "isSoulBackedByNative": true
 }

--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -105,6 +105,8 @@ abstract contract Artifacts {
         bytes32 digest = keccak256(bytes(_name));
         if (digest == keccak256(bytes("L2CrossDomainMessenger"))) {
             return payable(Predeploys.L2_CROSS_DOMAIN_MESSENGER);
+        } else if (digest == keccak256(bytes("SoulGasToken"))) {
+            return payable(Predeploys.SOUL_GAS_TOKEN);
         } else if (digest == keccak256(bytes("L2ToL1MessagePasser"))) {
             return payable(Predeploys.L2_TO_L1_MESSAGE_PASSER);
         } else if (digest == keccak256(bytes("L2StandardBridge"))) {

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -236,6 +236,16 @@ contract DeployConfig is Script {
         useInterop = _useInterop;
     }
 
+    /// @notice Allow the `useSoulGasToken` config to be overridden in testing environments
+    function setUseSoulGasToken(bool _useSoulGasToken) public {
+        useSoulGasToken = _useSoulGasToken;
+    }
+
+    /// @notice Allow the `isSoulBackedByNative` config to be overridden in testing environments
+    function setIsSoulBackedByNative(bool _isSoulBackedByNative) public {
+        isSoulBackedByNative = _isSoulBackedByNative;
+    }
+
     /// @notice Allow the `fundDevAccounts` config to be overridden.
     function setFundDevAccounts(bool _fundDevAccounts) public {
         fundDevAccounts = _fundDevAccounts;

--- a/packages/contracts-bedrock/src/L2/SoulGasToken.sol
+++ b/packages/contracts-bedrock/src/L2/SoulGasToken.sol
@@ -45,7 +45,7 @@ contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
 
     constructor(bool isBackedByNative_) {
         IS_BACKED_BY_NATIVE = isBackedByNative_;
-        initialize("SoulGasToken", "SGT", msg.sender);
+        initialize("", "", msg.sender);
     }
 
     /// @notice Initializer.

--- a/packages/contracts-bedrock/src/L2/SoulGasToken.sol
+++ b/packages/contracts-bedrock/src/L2/SoulGasToken.sol
@@ -45,6 +45,7 @@ contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
 
     constructor(bool isBackedByNative_) {
         IS_BACKED_BY_NATIVE = isBackedByNative_;
+        initialize("SoulGasToken", "SGT", msg.sender);
     }
 
     /// @notice Initializer.

--- a/packages/contracts-bedrock/src/L2/interfaces/ISoulGasToken.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/ISoulGasToken.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 /// @title ISoulGasToken
 /// @notice The interface for the SoulGasToken.
 interface ISoulGasToken {
-    function initialize(string memory name_, string memory symbol_, address owner_) external;
+    function initialize(string memory _name, string memory _symbol, address _owner) external;
 
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/src/L2/interfaces/ISoulGasToken.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/ISoulGasToken.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title ISoulGasToken
+/// @notice The interface for the SoulGasToken.
+interface ISoulGasToken {
+    function initialize(string memory name_, string memory symbol_, address owner_) external;
+
+    function __constructor__() external;
+}

--- a/packages/contracts-bedrock/test/setup/CommonTest.sol
+++ b/packages/contracts-bedrock/test/setup/CommonTest.sol
@@ -24,6 +24,8 @@ contract CommonTest is Test, Setup, Events {
     bool useLegacyContracts;
     address customGasToken;
     bool useInteropOverride;
+    bool useSoulGasToken;
+    bool isSoulBackedByNative;
 
     ERC20 L1Token;
     ERC20 BadL1Token;
@@ -54,6 +56,12 @@ contract CommonTest is Test, Setup, Events {
         }
         if (useInteropOverride) {
             deploy.cfg().setUseInterop(true);
+        }
+        if (useSoulGasToken) {
+            deploy.cfg().setUseSoulGasToken(true);
+            if (isSoulBackedByNative) {
+                deploy.cfg().setIsSoulBackedByNative(true);
+            }
         }
 
         vm.etch(address(ffi), vm.getDeployedCode("FFIInterface.sol:FFIInterface"));
@@ -209,5 +217,16 @@ contract CommonTest is Test, Setup, Events {
         }
 
         useInteropOverride = true;
+    }
+
+    function enableSoulGasToken() public {
+        // Check if the system has already been deployed, based off of the heuristic that alice and bob have not been
+        // set by the `setUp` function yet.
+        if (!(alice == address(0) && bob == address(0))) {
+            revert("CommonTest: Cannot enable interop after deployment. Consider overriding `setUp`.");
+        }
+
+        useSoulGasToken = true;
+        isSoulBackedByNative = true;
     }
 }

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -32,6 +32,7 @@ import { IDisputeGameFactory } from "src/dispute/interfaces/IDisputeGameFactory.
 import { IDelayedWETH } from "src/dispute/interfaces/IDelayedWETH.sol";
 import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
 import { IL2CrossDomainMessenger } from "src/L2/interfaces/IL2CrossDomainMessenger.sol";
+import { ISoulGasToken } from "src/L2/interfaces/ISoulGasToken.sol";
 import { IL2StandardBridgeInterop } from "src/L2/interfaces/IL2StandardBridgeInterop.sol";
 import { IL2ToL1MessagePasser } from "src/L2/interfaces/IL2ToL1MessagePasser.sol";
 import { IL2ERC721Bridge } from "src/L2/interfaces/IL2ERC721Bridge.sol";
@@ -111,6 +112,7 @@ contract Setup {
     ISuperchainTokenBridge superchainTokenBridge = ISuperchainTokenBridge(Predeploys.SUPERCHAIN_TOKEN_BRIDGE);
     IOptimismSuperchainERC20Factory l2OptimismSuperchainERC20Factory =
         IOptimismSuperchainERC20Factory(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY);
+    ISoulGasToken soulGasToken = ISoulGasToken(Predeploys.SOUL_GAS_TOKEN);
 
     /// @dev Deploys the Deploy contract without including its bytecode in the bytecode
     ///      of this contract by fetching the bytecode dynamically using `vm.getCode()`.
@@ -237,6 +239,7 @@ contract Setup {
         labelPredeploy(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY);
         labelPredeploy(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_BEACON);
         labelPredeploy(Predeploys.SUPERCHAIN_TOKEN_BRIDGE);
+        labelPredeploy(Predeploys.SOUL_GAS_TOKEN);
 
         // L2 Preinstalls
         labelPreinstall(Preinstalls.MultiCall3);

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -45,6 +45,7 @@ contract Initializer_Test is CommonTest {
     function setUp() public override {
         super.enableAltDA();
         super.enableLegacyContracts();
+        super.enableSoulGasToken();
         super.setUp();
 
         // Initialize the `contracts` array with the addresses of the contracts to test, the

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -266,6 +266,14 @@ contract Initializer_Test is CommonTest {
                 initCalldata: abi.encodeCall(l2CrossDomainMessenger.initialize, (l1CrossDomainMessenger))
             })
         );
+        // SoulGasToken
+        contracts.push(
+            InitializeableContract({
+                name: "SoulGasToken",
+                target: address(soulGasToken),
+                initCalldata: abi.encodeCall(soulGasToken.initialize, ("SoulGasToken", "SGT", address(0)))
+            })
+        );
         // L1StandardBridgeImpl
         contracts.push(
             InitializeableContract({


### PR DESCRIPTION
Issue: 
The command `forge test --match-path test/vendor/Initializable.t.sol ` failed because `SoulGasToken` is `Initializable` but does not pass the `test_cannotReinitialize_succeeds` [check](https://github.com/ethstorage/optimism/blob/3834224b10c02a24a3ea874cbcb138518e11ccf2/packages/contracts-bedrock/test/vendor/Initializable.t.sol#L392).

Solution: 
 - Add SoulGasToken to the test contracts list.
 - Ensure it is deployed during testing (update hardhat.json accordingly).
 - Add an initialize() call in SoulGasToken’s constructor. This is considered best practice and aligns with references: 
     - [OpenZeppelin guide](https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#initializing_the_implementation_contract)
     - [Optimism Style Guide](https://github.com/ethstorage/optimism/blob/develop/packages/contracts-bedrock/STYLE_GUIDE.md#proxy-by-default)
     - [L2CrossDomainMessenger example](https://github.com/ethstorage/optimism/blob/3834224b10c02a24a3ea874cbcb138518e11ccf2/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol#L28) 