### PR TITLE
Fix `make lint-go` error

### DIFF
--- a/op-node/rollup/derive/blob_data_source_test.go
+++ b/op-node/rollup/derive/blob_data_source_test.go
@@ -45,7 +45,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	}
 	calldataTx, _ := types.SignNewTx(privateKey, signer, txData)
 	txs := types.Transactions{calldataTx}
-	data, blobHashes := dataAndHashesFromTxs(txs, &config, batcherAddr, logger, map[common.Hash]bool{calldataTx.Hash(): true})
+	data, blobHashes := dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
 	require.Equal(t, 1, len(data))
 	require.Equal(t, 0, len(blobHashes))
 
@@ -60,14 +60,14 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	}
 	blobTx, _ := types.SignNewTx(privateKey, signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger, map[common.Hash]bool{blobTx.Hash(): true})
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
 	require.Equal(t, 1, len(data))
 	require.Equal(t, 1, len(blobHashes))
 	require.Nil(t, data[0].calldata)
 
 	// try again with both the blob & calldata transactions and make sure both are picked up
 	txs = types.Transactions{blobTx, calldataTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger, map[common.Hash]bool{blobTx.Hash(): true, calldataTx.Hash(): true})
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
 	require.Equal(t, 2, len(data))
 	require.Equal(t, 1, len(blobHashes))
 	require.NotNil(t, data[1].calldata)
@@ -75,7 +75,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	// make sure blob tx to the batch inbox is ignored if not signed by the batcher
 	blobTx, _ = types.SignNewTx(testutils.RandomKey(), signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger, map[common.Hash]bool{blobTx.Hash(): true})
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
 	require.Equal(t, 0, len(data))
 	require.Equal(t, 0, len(blobHashes))
 
@@ -84,7 +84,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	blobTxData.To = testutils.RandomAddress(rng)
 	blobTx, _ = types.SignNewTx(privateKey, signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger, map[common.Hash]bool{blobTx.Hash(): true})
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
 	require.Equal(t, 0, len(data))
 	require.Equal(t, 0, len(blobHashes))
 }


### PR DESCRIPTION
The `make lint-go` command failed due to compilation errors. The `dataAndHashesFromTxs` function takes 4 input parameters instead of 5, so removing the last parameter resolves the issue, allowing the command and tests to pass successfully.