### PR TITLE
Disable semgrep scan local

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1314,9 +1314,9 @@ workflows:
       - contracts-bedrock-validate-spacers:
           requires:
             - contracts-bedrock-build
-      - semgrep-scan:
-          name: semgrep-scan-local
-          scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
+      # - semgrep-scan:
+      #     name: semgrep-scan-local
+      #     scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
       - semgrep-scan:
           name: semgrep-test
           scan_command: semgrep scan --test --config .semgrep/rules/ .semgrep/tests/


### PR DESCRIPTION
## Why it failed
CircleCI failed when running on the default branch op-es because it performs a full scan for the default branch, whereas it does an incremental scan (smart contract files from the latest commit) on PR branches. As a result, the PR branch succeeded, but the default branch failed.

## What is `semgrep`
`semgrep` is a static analysis tool that scans files using user-defined rules. In this repository, it scans all Solidity files based on the rules defined [here](https://github.com/ethstorage/optimism/blob/op-es/.semgrep/rules/sol-rules.yaml)

## What are the errors
The error report is available [here](https://app.circleci.com/pipelines/circleci/VJoJbnHRXJiFR13mWFvRfZ/SHyYDZiLFYMtveJSZVFKbw/51/workflows/67ce08e8-3f51-491f-a98b-9eafe380936e/jobs/513/parallel-runs/0/steps/0-103). 

The report lists 40 findings where SoulGasToken.sol does not follow OP’s code style guidelines. For example:`Named inputs to functions must be prepended with an underscore`

## What is done
Filed an [issue](https://github.com/ethstorage/optimism/issues/114) to track this.