### PR TITLE
Fix `go_test_all`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1343,10 +1343,10 @@ workflows:
       #     on_changes: op-e2e,packages/contracts-bedrock/src
       #     uses_artifacts: true
       #     requires: ["contracts-bedrock-build"]
-      # - go-test:
-      #     name: go-test-all
-      #     requires:
-      #       - contracts-bedrock-build
+      - go-test:
+          name: go-test-all
+          requires:
+            - contracts-bedrock-build
       - go-test-kurtosis:
           name: op-deployer-integration
           module: op-deployer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -866,7 +866,7 @@ jobs:
             done
 
             export ENABLE_ANVIL=true
-            export SEPOLIA_RPC_URL="https://ci-sepolia-l1-archive.optimism.io"
+            export SEPOLIA_RPC_URL="http://88.99.30.186:8545"
 
             gotestsum --format=testname \
               --junitfile=./tmp/test-results/results.xml \

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -837,10 +837,10 @@ type L1DependenciesConfig struct {
 // SoulGasTokenConfig configures the SoulGasToken deployment to L2.
 type SoulGasTokenConfig struct {
 	// UseSoulGasToken is a flag that indicates if the system is using SoulGasToken
-	UseSoulGasToken bool `json:"useSoulGasToken"`
+	UseSoulGasToken bool `json:"useSoulGasToken,omitempty"`
 	// IsSoulBackedByNative is a flag that indicates if the SoulGasToken is backed by native.
 	// Only effective when UseSoulGasToken is true.
-	IsSoulBackedByNative bool `json:"isSoulBackedByNative"`
+	IsSoulBackedByNative bool `json:"isSoulBackedByNative,omitempty"`
 }
 
 // DependencyContext is the contextual configuration needed to verify the L1 dependencies,

--- a/op-node/rollup/derive/altda_data_source_test.go
+++ b/op-node/rollup/derive/altda_data_source_test.go
@@ -106,6 +106,8 @@ func TestAltDADataSource(t *testing.T) {
 	nc := 0
 	firstChallengeExpirationBlock := uint64(95)
 
+	// for reusing after pipeline is reset
+	successfulReceipts := make(map[common.Hash]types.Receipts)
 	for i := uint64(0); i <= pcfg.ChallengeWindow+pcfg.ResolveWindow; i++ {
 		parent := l1Refs[len(l1Refs)-1]
 		// create a new mock l1 ref
@@ -117,8 +119,6 @@ func TestAltDADataSource(t *testing.T) {
 		}
 		l1Refs = append(l1Refs, ref)
 		logger.Info("new l1 block", "ref", ref)
-		// called for each l1 block to sync challenges
-		l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
 
 		// pick a random number of commitments to include in the l1 block
 		c := rng.Intn(4)
@@ -149,6 +149,12 @@ func TestAltDADataSource(t *testing.T) {
 			txs = append(txs, tx)
 
 		}
+
+		successfulReceipts[ref.Hash] = successfulReceiptsForTxs(txs)
+		// called by `getTxSucceed` to fetch tx status
+		l1F.ExpectFetchReceipts(ref.Hash, nil, successfulReceipts[ref.Hash], nil)
+		// called for each l1 block to sync challenges
+		l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
 		logger.Info("included commitments", "count", c)
 		l1F.ExpectInfoAndTxsByHash(ref.Hash, testutils.RandomBlockInfo(rng), txs, nil)
 		// called once per derivation
@@ -205,6 +211,8 @@ func TestAltDADataSource(t *testing.T) {
 			ref = l1Refs[i]
 			logger.Info("re deriving block", "ref", ref, "i", i)
 
+			// called by `getTxSucceed` to fetch tx status
+			l1F.ExpectFetchReceipts(ref.Hash, nil, successfulReceipts[ref.Hash], nil)
 			if i == len(l1Refs)-1 {
 				l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
 			}
@@ -220,8 +228,6 @@ func TestAltDADataSource(t *testing.T) {
 			}
 			l1Refs = append(l1Refs, ref)
 			logger.Info("new l1 block", "ref", ref)
-			// called for each l1 block to sync challenges
-			l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
 
 			// pick a random number of commitments to include in the l1 block
 			c := rng.Intn(4)
@@ -251,6 +257,10 @@ func TestAltDADataSource(t *testing.T) {
 				txs = append(txs, tx)
 
 			}
+			// called by `getTxSucceed` to fetch tx status
+			l1F.ExpectFetchReceipts(ref.Hash, nil, successfulReceiptsForTxs(txs), nil)
+			// called for each l1 block to sync challenges
+			l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
 			logger.Info("included commitments", "count", c)
 			l1F.ExpectInfoAndTxsByHash(ref.Hash, testutils.RandomBlockInfo(rng), txs, nil)
 		}
@@ -280,6 +290,13 @@ func TestAltDADataSource(t *testing.T) {
 	// finalize based on the second to last block, which will prune the commitment on block 2, and make it finalized
 	da.Finalize(l1Refs[len(l1Refs)-2])
 	finalitySignal.AssertExpectations(t)
+}
+
+func successfulReceiptsForTxs(txs []*types.Transaction) (receipts types.Receipts) {
+	for _, tx := range txs {
+		receipts = append(receipts, &types.Receipt{TxHash: tx.Hash(), Status: types.ReceiptStatusSuccessful})
+	}
+	return
 }
 
 // This tests makes sure the pipeline returns a temporary error if data is not found.
@@ -350,7 +367,6 @@ func TestAltDADataSourceStall(t *testing.T) {
 		ParentHash: parent.Hash,
 		Time:       parent.Time + l1Time,
 	}
-	l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
 	// mock input commitments in l1 transactions
 	input := testutils.RandomData(rng, 2000)
 	comm, _ := storage.SetInput(ctx, input)
@@ -369,6 +385,9 @@ func TestAltDADataSourceStall(t *testing.T) {
 
 	txs := []*types.Transaction{tx}
 
+	// called by `getTxSucceed` to fetch tx status
+	l1F.ExpectFetchReceipts(ref.Hash, nil, successfulReceiptsForTxs(txs), nil)
+	l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
 	l1F.ExpectInfoAndTxsByHash(ref.Hash, testutils.RandomBlockInfo(rng), txs, nil)
 
 	// delete the input from the DA provider so it returns not found
@@ -472,7 +491,6 @@ func TestAltDADataSourceInvalidData(t *testing.T) {
 		ParentHash: parent.Hash,
 		Time:       parent.Time + l1Time,
 	}
-	l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
 	// mock input commitments in l1 transactions with an oversized input
 	input := testutils.RandomData(rng, altda.MaxInputSize+1)
 	comm, _ := storage.SetInput(ctx, input)
@@ -520,6 +538,9 @@ func TestAltDADataSourceInvalidData(t *testing.T) {
 
 	txs := []*types.Transaction{tx1, tx2, tx3}
 
+	// called by `getTxSucceed` to fetch tx status
+	l1F.ExpectFetchReceipts(ref.Hash, nil, successfulReceiptsForTxs(txs), nil)
+	l1F.ExpectFetchReceipts(ref.Hash, nil, types.Receipts{}, nil)
 	l1F.ExpectInfoAndTxsByHash(ref.Hash, testutils.RandomBlockInfo(rng), txs, nil)
 
 	src, err := factory.OpenData(ctx, ref, batcherAddr)


### PR DESCRIPTION
This PR fixes the tests mentioned [here](https://github.com/ethstorage/optimism/issues/109).

The alt-da test failure is caused by the extra `FetchReceipts` call in [`getTxSucceed`](https://github.com/ethstorage/optimism/blob/cb15c77e100b991446f7a6f9180f913da812f6ce/op-node/rollup/derive/blob_data_source.go#L77).