### PR TITLE
Disable contracts-bedrock-tests-heavy-fuzz-modified

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1300,13 +1300,13 @@ workflows:
           name: contracts-bedrock-tests-preimage-oracle
           test_parallelism: 1
           test_list: find test -name "PreimageOracle.t.sol"
-      - contracts-bedrock-tests:
-          # Heavily fuzz any fuzz tests within added or modified test files.
-          name: contracts-bedrock-tests-heavy-fuzz-modified
-          test_parallelism: 1
-          test_list: git diff origin/develop...HEAD --name-only -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
-          test_timeout: 1h
-          test_profile: ciheavy
+      # - contracts-bedrock-tests:
+      #     # Heavily fuzz any fuzz tests within added or modified test files.
+      #     name: contracts-bedrock-tests-heavy-fuzz-modified
+      #     test_parallelism: 1
+      #     test_list: git diff origin/op-es...HEAD --name-only -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
+      #     test_timeout: 1h
+      #     test_profile: ciheavy
       - contracts-bedrock-coverage
       # - contracts-bedrock-checks:
       #     requires:


### PR DESCRIPTION
The `contracts-bedrock-tests-heavy-fuzz-modified` job ran successfully and took about 30 mins along with a significant amount of credits. Therefore, we have decided to disable it for now.