### PR TITLE
feat: enable dac server in devnet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,6 @@
 [submodule "packages/contracts-bedrock/lib/solady-v0.0.245"]
 	path = packages/contracts-bedrock/lib/solady-v0.0.245
 	url = https://github.com/vectorized/solady
+[submodule "da-server"]
+	path = da-server
+	url = https://github.com/ethstorage/da-server

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -88,12 +88,28 @@ services:
     environment:
       GETH_MINER_RECOMMIT: 100ms
 
+  dac-server:
+    depends_on:
+      - l1
+      - l1-bn
+      - l1-vc
+    build:
+      context: ../
+      dockerfile: ops/docker/op-stack-go/Dockerfile
+      target: op-node-target
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:devnet
+    ports:
+      - 8888:8888
+    command: >
+      da-server da start --config /usr/local/bin/default.json
+
   op-node:
     depends_on:
       - l1
       - l1-bn
       - l1-vc
       - l2
+      - dac-server
     build:
       context: ../
       dockerfile: ops/docker/op-stack-go/Dockerfile
@@ -129,7 +145,7 @@ services:
       --altda.enabled=${ALTDA_ENABLED}
       --altda.da-service=${ALTDA_SERVICE}
       --altda.da-server=http://da-server:3100
-      --dac.urls=
+      --dac.urls=http://dac-server:8888
     ports:
       - "7545:8545"
       - "9003:9003"

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -110,6 +110,10 @@ ARG OP_NODE_VERSION=v0.0.0
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build cd op-chain-ops && make op-deployer  \
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_DEPLOYER_VERSION"
 
+FROM --platform=$BUILDPLATFORM builder AS dac-server-builder
+ARG OP_NODE_VERSION=v0.0.0
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build cd da-server && go build -o da-server main.go
+
 FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS cannon-target
 COPY --from=cannon-builder /app/cannon/bin/cannon /usr/local/bin/
 COPY --from=cannon-builder /app/cannon/multicannon/embeds/* /usr/local/bin/
@@ -125,6 +129,8 @@ CMD ["op-wheel"]
 
 FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-node-target
 COPY --from=op-node-builder /app/op-node/bin/op-node /usr/local/bin/
+COPY --from=dac-server-builder /app/da-server/da-server /usr/local/bin/
+COPY --from=dac-server-builder /app/da-server/default.json /usr/local/bin/
 CMD ["op-node"]
 
 FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS op-challenger-target

--- a/ops/docker/op-stack-go/Dockerfile.dockerignore
+++ b/ops/docker/op-stack-go/Dockerfile.dockerignore
@@ -18,5 +18,6 @@
 !/op-supervisor
 !/op-wheel
 !/op-alt-da
+!/da-server
 !/go.mod
 !/go.sum

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -49,7 +49,7 @@
   "l2GenesisEcotoneTimeOffset": "0x0",
   "l2GenesisFjordTimeOffset": "0x0",
   "l2GenesisGraniteTimeOffset": "0x0",
-  "l2GenesisBlobTimeOffset": "0xffffffff",
+  "l2GenesisBlobTimeOffset": "0x0",
   "l1CancunTimeOffset": "0x0",
   "systemConfigStartBlock": 0,
   "requiredProtocolVersion": "0x0000000000000000000000000000000000000000000000000000000000000001",


### PR DESCRIPTION
fix #82 

- Use submodule to import da-server code
- Compile the code inflight similar to other code
- Reuse op-node image to run the da-server in docker

Test:
- Follow the instructions here https://perfect-amphibian-929.notion.site/SWC-Devnet-1282e493e88380648486d4961eb91a8d?pvs=4
- Submit 4844 tx
- And check the data is stored in da-server container