### PR TITLE
CircleCI: fix fuzz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1332,18 +1332,18 @@ workflows:
                 - op-node
                 - op-service
                 - op-chain-ops
-      # - fuzz-golang:
-      #     name: cannon-fuzz
-      #     package_name: cannon
-      #     on_changes: cannon,packages/contracts-bedrock/src/cannon
-      #     uses_artifacts: true
-      #     requires: ["contracts-bedrock-build"]
-      # - fuzz-golang:
-      #     name: op-e2e-fuzz
-      #     package_name: op-e2e
-      #     on_changes: op-e2e,packages/contracts-bedrock/src
-      #     uses_artifacts: true
-      #     requires: ["contracts-bedrock-build"]
+      - fuzz-golang:
+          name: cannon-fuzz
+          package_name: cannon
+          on_changes: cannon,packages/contracts-bedrock/src/cannon
+          uses_artifacts: true
+          requires: ["contracts-bedrock-build"]
+      - fuzz-golang:
+          name: op-e2e-fuzz
+          package_name: op-e2e
+          on_changes: op-e2e,packages/contracts-bedrock/src
+          uses_artifacts: true
+          requires: ["contracts-bedrock-build"]
       - go-test:
           name: go-test-all
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ parameters:
     default: false
 
 orbs:
+  python: circleci/python@3.0.0
   go: circleci/go@1.8.0
   gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@4.10.1


### PR DESCRIPTION
Fix the fuzz-golang  related jobs mentioned in https://github.com/ethstorage/optimism/issues/112:

- fuzz-golang-op-service
- fuzz-golang-op-node
- fuzz-golang-op-challenger
- fuzz-golang-op-chain-ops
- op-e2e-fuzz

Caused by: 
pip3: command not found

Dependency: 
fuzz-golang -> check-changed -> pip3 install

