### PR TITLE
CircleCI: fix resource_class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -837,7 +837,7 @@ jobs:
         description: List of packages to test
         type: string
     machine: true
-    resource_class: <<parameters.resource_class>>
+    resource_class: swc/ax101
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
Need to specify the machine name to resource_class when using `machine: true`, otherwise, it will use a container that has no required dependencies.