### PR TITLE
CircleCI: fix op-node-docker-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,6 +408,8 @@ jobs:
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     steps:
       - checkout
+      - run:
+          command: git submodule update --init
       - attach_workspace:
           at: /tmp/docker_images
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,25 +119,15 @@ commands:
             pip3 install -r requirements.txt
             python3 main.py "<<parameters.patterns>>"
 
-  update-git-submodules:
-    description: "Update git submodules"
-    parameters:
-      working_directory:
-        type: string
-        description: "The working directory for the command"
+  install-contracts-dependencies:
+    description: "Install the dependencies for the smart contracts"
     steps:
       - run:
-          name: "Update Git Submodules"
+          name: Install dependencies
           command: |
             # Manually craft the submodule update command in order to take advantage
             # of the -j parameter, which speeds it up a lot.
             git submodule update --init --recursive --force -j 8
-          working_directory: << parameters.working_directory >>
-
-  install-contracts-dependencies:
-    description: "Install the dependencies for the smart contracts"
-    steps:
-      - update-git-submodules:
           working_directory: packages/contracts-bedrock
 
   notify-failures-on-develop:
@@ -418,8 +408,8 @@ jobs:
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     steps:
       - checkout
-      - update-git-submodules:
-          working_directory: .
+      - run:
+          command: git submodule update --init
       - attach_workspace:
           at: /tmp/docker_images
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,15 +119,25 @@ commands:
             pip3 install -r requirements.txt
             python3 main.py "<<parameters.patterns>>"
 
-  install-contracts-dependencies:
-    description: "Install the dependencies for the smart contracts"
+  update-git-submodules:
+    description: "Update git submodules"
+    parameters:
+      working_directory:
+        type: string
+        description: "The working directory for the command"
     steps:
       - run:
-          name: Install dependencies
+          name: "Update Git Submodules"
           command: |
             # Manually craft the submodule update command in order to take advantage
             # of the -j parameter, which speeds it up a lot.
             git submodule update --init --recursive --force -j 8
+          working_directory: << parameters.working_directory >>
+
+  install-contracts-dependencies:
+    description: "Install the dependencies for the smart contracts"
+    steps:
+      - update-git-submodules:
           working_directory: packages/contracts-bedrock
 
   notify-failures-on-develop:
@@ -408,8 +418,8 @@ jobs:
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     steps:
       - checkout
-      - run:
-          command: git submodule update --init
+      - update-git-submodules:
+          working_directory: .
       - attach_workspace:
           at: /tmp/docker_images
       - run:

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -128,7 +128,6 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 FROM --platform=$BUILDPLATFORM builder AS dac-server-builder
 ARG OP_NODE_VERSION=v0.0.0
-RUN git clone --single-branch --branch main https://github.com/ethstorage/da-server da-server
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build cd da-server && go build -o da-server main.go
 
 FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS cannon-target

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -128,6 +128,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 FROM --platform=$BUILDPLATFORM builder AS dac-server-builder
 ARG OP_NODE_VERSION=v0.0.0
+RUN git clone --single-branch --branch main https://github.com/ethstorage/da-server da-server
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build cd da-server && go build -o da-server main.go
 
 FROM --platform=$TARGETPLATFORM $TARGET_BASE_IMAGE AS cannon-target


### PR DESCRIPTION
[Error log](https://app.circleci.com/pipelines/circleci/VJoJbnHRXJiFR13mWFvRfZ/SHyYDZiLFYMtveJSZVFKbw/65/workflows/59eb8321-99c7-42d9-92f2-d36029763d6b/jobs/1325): 

```log
ERROR: process "/bin/sh -c cd da-server && go build -o da-server main.go" did not complete successfully: exit code: 1
```

The error happens because there is no code to build, so we update the submodules before build.

