### PR TITLE
fix go run ./scripts/checks/interfaces

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/interfaces/main.go
+++ b/packages/contracts-bedrock/scripts/checks/interfaces/main.go
@@ -30,7 +30,7 @@ var excludeContracts = []string{
 
 	"IInitializable", "IOptimismMintableERC20", "ILegacyMintableERC20",
 	"KontrolCheatsBase", "ISystemConfigInterop", "IResolvedDelegateProxy",
-	"IERC20Upgradeable",
+	"IERC20Upgradeable", "ISoulGasToken",
 }
 
 type ContractDefinition struct {


### PR DESCRIPTION
This PR fixes the issue of `go run ./scripts/checks/interfaces` caused by newly added `./interfaces/L2/ISoulGasToken.sol`.

(Note the issue won't be discovered if we don't rebuild the forge-artifacts.)