### PR TITLE
CircleCI: contracts-bedrock-checks / fix semver-diff-check-no-build

### DIFF
--- a/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
@@ -32,14 +32,14 @@ temp_dir=$(mktemp -d)
 trap 'rm -rf "$temp_dir"' EXIT
 
 # Exit early if semver-lock.json has not changed.
-if ! { git diff origin/develop...HEAD --name-only; git diff --name-only; git diff --cached --name-only; } | grep -q "$SEMVER_LOCK"; then
+if ! { git diff origin/op-es...HEAD --name-only; git diff --name-only; git diff --cached --name-only; } | grep -q "$SEMVER_LOCK"; then
     echo "No changes detected in semver-lock.json"
     exit 0
 fi
 
 # Get the upstream semver-lock.json.
-if ! git show origin/develop:packages/contracts-bedrock/snapshots/semver-lock.json > "$temp_dir/upstream_semver_lock.json" 2>/dev/null; then
-      echo "❌ Error: Could not find semver-lock.json in the snapshots/ directory of develop branch"
+if ! git show origin/op-es:packages/contracts-bedrock/snapshots/semver-lock.json > "$temp_dir/upstream_semver_lock.json" 2>/dev/null; then
+      echo "❌ Error: Could not find semver-lock.json in the snapshots/ directory of op-es branch"
       exit 1
 fi
 
@@ -80,7 +80,7 @@ for contract in $changed_contracts; do
     # Extract the old and new source files.
     old_source_file="$temp_dir/old_${contract##*/}"
     new_source_file="$temp_dir/new_${contract##*/}"
-    git show origin/develop:packages/contracts-bedrock/"$contract" > "$old_source_file" 2>/dev/null || true
+    git show origin/op-es:packages/contracts-bedrock/"$contract" > "$old_source_file" 2>/dev/null || true
     cp "$contract" "$new_source_file"
 
     # Extract the old and new versions.


### PR DESCRIPTION
This is another PR to fix https://github.com/ethstorage/optimism/issues/111

Error [log](https://app.circleci.com/pipelines/circleci/VJoJbnHRXJiFR13mWFvRfZ/SHyYDZiLFYMtveJSZVFKbw/78/workflows/4588823b-fad2-48e0-abf7-41f5cf2021eb/jobs/1503):

```
./scripts/checks/check-semver-diff.sh
❌ Error: Could not find semver-lock.json in the snapshots/ directory of develop branch
error: Recipe `semver-diff-check-no-build` failed on line 155 with exit code 1

Exited with code exit status 1
```

Fix: 

Use the correct branch `op-es` instead of `develop`. 

