### PR TITLE
CircleCi: fix fp related tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1633,15 +1633,15 @@ workflows:
   #         requires:
   #           - <<matrix.op_component>>-docker-publish
 
-  # scheduled-preimage-reproducibility:
-  #   when:
-  #     or:
-  #       - equal: [build_daily, <<pipeline.schedule.name>>]
-  #       # Trigger on manual triggers if explicitly requested
-  #       - equal: [true, << pipeline.parameters.reproducibility_dispatch >>]
-  #   jobs:
-  #     - preimage-reproducibility:
-  #         context: slack
+  scheduled-preimage-reproducibility:
+    when:
+      or:
+        - equal: [build_daily, <<pipeline.schedule.name>>]
+        # Trigger on manual triggers if explicitly requested
+        - equal: [true, << pipeline.parameters.reproducibility_dispatch >>]
+    jobs:
+      - preimage-reproducibility:
+          context: slack
 
   # scheduled-stale-check:
   #   when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1064,8 +1064,8 @@ jobs:
 
   fpp-verify:
     circleci_ip_ranges: true
-    docker:
-      - image: cimg/go:1.21
+    machine: true
+    resource_class: swc/ax101
     steps:
       - checkout
       - run:
@@ -1494,14 +1494,14 @@ workflows:
   #         context:
   #           - slack
 
-  # scheduled-fpp:
-  #   when:
-  #     equal: [build_hourly, <<pipeline.schedule.name>>]
-  #   jobs:
-  #     - fpp-verify:
-  #         context:
-  #           - slack
-  #           - oplabs-fpp-nodes
+  scheduled-fpp:
+    when:
+      equal: [build_hourly, <<pipeline.schedule.name>>]
+    jobs:
+      - fpp-verify:
+          context:
+            - slack
+            - oplabs-fpp-nodes
 
   # develop-publish-contract-artifacts:
   #   when:
@@ -1523,39 +1523,39 @@ workflows:
   #   jobs:
   #     - contracts-bedrock-coverage
 
-  # develop-fault-proofs:
-  #   when:
-  #     and:
-  #       - or:
-  #           - equal: ["develop", <<pipeline.git.branch>>]
-  #           - equal: [true, <<pipeline.parameters.fault_proofs_dispatch>>]
-  #       - not:
-  #           equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-  #   jobs:
-  #     - go-mod-download
-  #     - cannon-prestate
-  #     - cannon-stf-verify:
-  #         requires:
-  #           - go-mod-download
-  #         context:
-  #           - slack
-  #     - contracts-bedrock-build:
-  #         build_args: --deny-warnings --skip test
-  #         context:
-  #           - slack
-  #     - go-tests:
-  #         name: op-e2e-cannon-tests
-  #         notify: true
-  #         mentions: "@proofs-team"
-  #         no_output_timeout: 60m
-  #         test_timeout: 59m
-  #         resource_class: ethereum-optimism/latitude-fps-1
-  #         environment_overrides: |
-  #           export OP_E2E_CANNON_ENABLED="true"
-  #         packages: |
-  #           op-e2e/faultproofs
-  #         context:
-  #           - slack
+  develop-fault-proofs:
+    when:
+      and:
+        - or:
+            - equal: ["develop", <<pipeline.git.branch>>]
+            - equal: [true, <<pipeline.parameters.fault_proofs_dispatch>>]
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+    jobs:
+      - go-mod-download
+      - cannon-prestate
+      - cannon-stf-verify:
+          requires:
+            - go-mod-download
+          context:
+            - slack
+      - contracts-bedrock-build:
+          build_args: --deny-warnings --skip test
+          context:
+            - slack
+      - go-tests:
+          name: op-e2e-cannon-tests
+          notify: true
+          mentions: "@proofs-team"
+          no_output_timeout: 60m
+          test_timeout: 59m
+          resource_class: swc/ax101
+          environment_overrides: |
+            export OP_E2E_CANNON_ENABLED="true"
+          packages: |
+            op-e2e/faultproofs
+          context:
+            - slack
 
   # develop-kontrol-tests:
   #   when:
@@ -1571,23 +1571,23 @@ workflows:
   #           - slack
   #           - runtimeverification
 
-  # scheduled-cannon-full-tests:
-  #   when:
-  #     or:
-  #       - equal: [build_four_hours, <<pipeline.schedule.name>>]
-  #       - equal: [true, << pipeline.parameters.cannon_full_test_dispatch >>]
-  #   jobs:
-  #     - contracts-bedrock-build:
-  #         build_args: --deny-warnings --skip test
-  #     - cannon-go-lint-and-test:
-  #         name: cannon-go-lint-and-test-<<matrix.mips_word_size>>-bit
-  #         requires:
-  #           - contracts-bedrock-build
-  #         context:
-  #           - slack
-  #         matrix:
-  #           parameters:
-  #             mips_word_size: [32, 64]
+  scheduled-cannon-full-tests:
+    when:
+      or:
+        - equal: [build_four_hours, <<pipeline.schedule.name>>]
+        - equal: [true, << pipeline.parameters.cannon_full_test_dispatch >>]
+    jobs:
+      - contracts-bedrock-build:
+          build_args: --deny-warnings --skip test
+      - cannon-go-lint-and-test:
+          name: cannon-go-lint-and-test-<<matrix.mips_word_size>>-bit
+          requires:
+            - contracts-bedrock-build
+          context:
+            - slack
+          matrix:
+            parameters:
+              mips_word_size: [32, 64]
 
   # scheduled-docker-publish:
   #   when:

--- a/op-program/prestates/releases.json
+++ b/op-program/prestates/releases.json
@@ -1,72 +1,7 @@
 [
   {
-    "version": "1.4.0-rc.2",
-    "hash": "0x0364e4e72922e7d649338f558f8a14b50ca31922a1484e73ea03987fb1516095"
-  }, {
-    "version": "1.4.0-rc.1",
-    "hash": "0x03925193e3e89f87835bbdf3a813f60b2aa818a36bbe71cd5d8fd7e79f5e8afe"
-  },
-  {
-    "version": "1.3.1",
-    "hash": "0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c",
+    "version": "0.1",
+    "hash": "0x03a9deca8ceb15b1bfe60c98bed2305353b33859a2ffa4dd8c2f5641c4d99a23",
     "governanceApproved": true
-  },
-  {
-    "version": "1.3.1-rc.2",
-    "hash": "0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c"
-  },
-  {
-    "version": "1.3.1-rc.1",
-    "hash": "0x03e806a2859a875267a563462a06d4d1d1b455a9efee959a46e21e54b6caf69a"
-  },
-  {
-    "version": "1.3.0-rc.3",
-    "hash": "0x030de10d9da911a2b180ecfae2aeaba8758961fc28262ce989458c6f9a547922"
-  },
-  {
-    "version": "1.3.0-rc.2",
-    "hash": "0x0385c3f8ee78491001d92b90b07d0cf387b7b52ab9b83b4d87c994e92cf823ba"
-  },
-  {
-    "version": "1.3.0-rc.1",
-    "hash": "0x0367c4aa897bffbded0b523f277ca892298dc3c691baf37bc2099b86024f9673"
-  },
-  {
-    "version": "1.2.0",
-    "hash": "0x03617abec0b255dc7fc7a0513a2c2220140a1dcd7a1c8eca567659bd67e05cea",
-    "governanceApproved": true
-  },
-  {
-    "version": "1.1.0",
-    "hash": "0x03e69d3de5155f4a80da99dd534561cbddd4f9dd56c9ecc704d6886625711d2b"
-  },
-  {
-    "version": "1.0.1",
-    "hash": "0x0398bdd93e2e9313befdf82beb709da6a4daf35ce1abb42d8a998ec9bc1c572e"
-  },
-  {
-    "version": "1.0.0",
-    "hash": "0x037ef3c1a487960b0e633d3e513df020c43432769f41a634d18a9595cbf53c55",
-    "governanceApproved": true
-  },
-  {
-    "version": "0.3.1",
-    "hash": "0x037ef3c1a487960b0e633d3e513df020c43432769f41a634d18a9595cbf53c55"
-  },
-  {
-    "version": "0.3.0",
-    "hash": "0x034c8cc69f22c35ae386a97136715dd48aaf97fd190942a111bfa680c2f2f421"
-  },
-  {
-    "version": "0.2.0",
-    "hash": "0x031e3b504740d0b1264e8cf72b6dde0d497184cfb3f98e451c6be8b33bd3f808"
-  },
-  {
-    "version": "0.1.0",
-    "hash": "0x038942ec840131a63c49fa514a3f0577ae401fd5584d56ad50cdf5a8b41d4538"
-  },
-  {
-    "version": "0.0.1",
-    "hash": "0x03babef4b4c6d866d56e6356d961839fd9475931d11e0ea507420a87b0cadbdd"
   }
 ]

--- a/op-program/scripts/build-prestates.sh
+++ b/op-program/scripts/build-prestates.sh
@@ -12,7 +12,7 @@ cd "${TMP_DIR}"
 
 # Need to check out a fresh copy of the monorepo so we can switch to specific tags without it also affecting the
 # contents of this script (which is checked into the repo).
-git clone https://github.com/ethereum-optimism/optimism --recurse-submodules
+git clone https://github.com/ethstorage/optimism --recurse-submodules
 
 STATES_DIR="${SCRIPTS_DIR}/../temp/states"
 LOGS_DIR="${SCRIPTS_DIR}/../temp/logs"


### PR DESCRIPTION
## Description
This PR address issues in https://github.com/ethstorage/optimism/issues/113.

- [x] scheduled-fpp: done
   - add `oplabs-fpp-nodes` [context](https://app.circleci.com/settings/organization/circleci/VJoJbnHRXJiFR13mWFvRfZ/contexts) to CircleCi with envs: `SEPOLIA_L1URL`, `SEPOLIA_BEACON_URL` and `SEPOLIA_L2URL` (**requires archive node with `debug` api enabled**)
   - replace  `docker` machine with `swc/ax101`
   - it requires a **significant amount of time (~30 minutes)** to complete, which may **delay other tasks that rely on the swc/ax101** resource class
- [x] develop-fault-proofs: done
   - replace resource class of `ethereum-optimism/latitude-fps-1` with `swc/ax101` 
- [ ] ~~develop-kontrol-tests~~: leave it
   - it's an ad-hoc feature developed by https://github.com/runtimeverification to do formal verification for `OptimismPortal` related contracts, we can't use it
- [x] scheduled-cannon-full-tests: already fixed by add `codecov` to `orbs` in `config.yaml`
- [x]  scheduled-preimage-reproducibility:
   - Check that the prestate hash configured in op-program/prestates/releases.json matches the prestate hash in all op-program/{version} released tags
   - There must be at one `GovernanceApproved` release in `op-program/prestates/releases.json` 

## Tests
Enable: `fault_proofs_dispatch`, `cannon_full_test_dispatch` and `reproducibility_dispatch` in pipeline trigger
CircleCi passed in 
https://app.circleci.com/pipelines/circleci/VJoJbnHRXJiFR13mWFvRfZ/SHyYDZiLFYMtveJSZVFKbw/87
https://app.circleci.com/pipelines/circleci/VJoJbnHRXJiFR13mWFvRfZ/SHyYDZiLFYMtveJSZVFKbw/105
