### PR TITLE
CircleCI: fix go-tests / TestOPCMLiveChain/sepolia/sepolia-v1.8.0-rc.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -869,7 +869,7 @@ jobs:
             export OP_E2E_SKIP_SLOW_TEST=true
             export OP_E2E_USE_HTTP=true
             export ENABLE_ANVIL=true
-            export SEPOLIA_RPC_URL="https://ci-sepolia-l1-archive.optimism.io"
+            export SEPOLIA_RPC_URL="http://88.99.30.186:8545"
             export MAINNET_RPC_URL="https://ci-mainnet-l1-archive.optimism.io"
 
             <<parameters.environment_overrides>>

--- a/op-e2e/e2eutils/retryproxy/proxy.go
+++ b/op-e2e/e2eutils/retryproxy/proxy.go
@@ -162,6 +162,7 @@ func (p *RetryProxy) doProxyReq(ctx context.Context, body []byte) (*http.Respons
 	if err != nil {
 		panic(fmt.Errorf("failed to create request: %w", err))
 	}
+	req.Header.Set("Content-Type", "application/json")
 	res, err := p.client.Do(req)
 	if err != nil {
 		p.lgr.Warn("failed to proxy request", "err", err)


### PR DESCRIPTION
Error [log](https://app.circleci.com/pipelines/circleci/VJoJbnHRXJiFR13mWFvRfZ/SHyYDZiLFYMtveJSZVFKbw/88/workflows/20c94de8-9650-4241-abe2-75ed5fc944d3/jobs/1558/tests):

```
        proxy.go:82:                INFO [12-23|06:51:58.333] server started                           module=retryproxy port=43673
        proxy.go:172:               WARN [12-23|06:51:58.422] unexpected status code                   module=retryproxy status=415
        proxy.go:121:               WARN [12-23|06:51:58.422] failed to proxy request                  module=retryproxy err="unexpected status code: 415"
        proxy.go:172:               WARN [12-23|06:51:59.862] unexpected status code                   module=retryproxy status=415
        proxy.go:121:               WARN [12-23|06:51:59.863] failed to proxy request                  module=retryproxy err="unexpected status code: 415"
        proxy.go:172:               WARN [12-23|06:52:02.400] unexpected status code                   module=retryproxy status=415
        proxy.go:121:               WARN [12-23|06:52:02.400] failed to proxy request                  module=retryproxy err="unexpected status code: 415"
        proxy.go:172:               WARN [12-23|06:52:06.944] unexpected status code                   module=retryproxy status=415
        proxy.go:121:               WARN [12-23|06:52:06.944] failed to proxy request                  module=retryproxy err="unexpected status code: 415"
        proxy.go:172:               WARN [12-23|06:52:12.064] unexpected status code                   module=retryproxy status=415
        proxy.go:121:               WARN [12-23|06:52:12.064] failed to proxy request                  module=retryproxy err="unexpected status code: 415"
        proxy.go:135:               ERROR[12-23|06:52:12.064] permanently failed to proxy request      module=retryproxy err="operation failed permanently after 5 attempts: unexpected status code: 415"
        anvil.go:113:               DEBUG[12-23|06:52:12.064] [ANVIL] thread 'main' panicked at /home/runner/work/foundry/foundry/crates/anvil/src/config.rs:1147:57:
        anvil.go:113:               DEBUG[12-23|06:52:12.064] [ANVIL] Failed to get fork block number: Transport(HttpError(HttpError { status: 502, body: "failed to proxy request\n" }))
        anvil.go:113:               DEBUG[12-23|06:52:12.064] "[ANVIL] note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"
        opcm_test.go:63: 
                Error Trace:    /root/dl/circleci/optimism/op-deployer/pkg/deployer/bootstrap/opcm_test.go:63
/root/dl/circleci/optimism/op-deployer/pkg/deployer/bootstrap/opcm_test.go:33
                Error:          Received unexpected error:
                                context deadline exceeded
                Test:           TestOPCMLiveChain/sepolia-v1.8.0-rc.3
```
Status code 415 means "Unsupported Media Type" and "http://88.99.30.186:8545" looks cannot handle request without a specified content-type.   

CircleCI tests passed with the fix in [the latest run](https://app.circleci.com/pipelines/circleci/VJoJbnHRXJiFR13mWFvRfZ/SHyYDZiLFYMtveJSZVFKbw/89/workflows/e3d16f7b-d38f-4510-904b-b4a9931415c8/jobs/1562/tests).