### PR TITLE
CircleCI: fix go tests / env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -869,8 +869,6 @@ jobs:
             export OP_E2E_SKIP_SLOW_TEST=true
             export OP_E2E_USE_HTTP=true
             export ENABLE_ANVIL=true
-            export SEPOLIA_RPC_URL="https://ci-sepolia-l1-archive.optimism.io"
-            export MAINNET_RPC_URL="https://ci-mainnet-l1-archive.optimism.io"
 
             <<parameters.environment_overrides>>
 


### PR DESCRIPTION
Use `Project Settings/Environment Variables` instead of hardcode in config to prevent information leaks.
For the mainnet, a blockPI API Key was newly applied to replace the one from upstream. 

The related tests passed include
- TestApplyExistingOPCM/mainnet
- TestOPCMLiveChain/sepolia-v1.8.0-rc.3
- TestOPCMLiveChain/sepolia