### PR TITLE
CircleCI: fix a missing word

### DIFF
--- a/packages/contracts-bedrock/snapshots/abi/SoulGasToken.json
+++ b/packages/contracts-bedrock/snapshots/abi/SoulGasToken.json
@@ -8,8 +8,7 @@
       }
     ],
     "stateMutability": "nonpayable",
-    "type": "
-"
+    "type": "constructor"
   },
   {
     "inputs": [


### PR DESCRIPTION
Fix the error that breaks `snapshot-test`.

