### PR TITLE
CircleCI: fix contracts-bedrock-tests/testFuzz_blockHash(test name)

### DIFF
--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -166,7 +166,7 @@ contract L1BlockEcotone_Test is L1BlockTest {
 
     /// @dev Tests that `blockHash` works for block range [n-256, n) where n is the latest
     /// L1 block number known by the L2 system.
-    function testFuzz_blockHash(
+    function testFuzz_blockHash_succeeds(
         uint32 baseFeeScalar,
         uint32 blobBaseFeeScalar,
         uint64 sequenceNumber,


### PR DESCRIPTION
Error log:

```log

❌  L1BlockEcotone_Test.json: testFuzz_blockHash: test names should have either 3 or 4 parts, each separated by underscores
error: processing failed
exit status 1
```

The error can be found by:

```bash
just lint-forge-tests-check-no-build
# or
go run ./scripts/checks/test-names
```
The fix can be verified using the same command.


We did not find this error in CircleCI because we have the job `contracts-bedrock-tests` commented.
