### PR TITLE
A test script working with `mise`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ __pycache__
 
 # Ignore echidna artifacts
 crytic-export
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,3 @@ __pycache__
 
 # Ignore echidna artifacts
 crytic-export
-.vscode/settings.json

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -4,21 +4,21 @@ set -e
 #MISE description="Developers' local tests"
 #MISE alias="dt"
 
+# Just for environment test
 forge --version
 
+# Solidity
+
 cd packages/contracts-bedrock
-
 just pre-pr
-
 just test
 
+# Go
+
 cd ../..
-
 make lint-go
-
 make build
 
-# # Build other essential components
 cd op-program && make op-program-client && cd ..
 cd cannon && make elf && cd ..
 cd op-e2e && make pre-test && cd ..
@@ -29,6 +29,8 @@ export OP_E2E_SKIP_SLOW_TEST=true
 export OP_E2E_USE_HTTP=true
 export ENABLE_ANVIL=true
 
+# Note: not all packages are tested.
+# For example the test `TestFinalization` in `op-alt-da` package fails even in upstream.
 packages=(
     op-batcher
     op-chain-ops
@@ -58,9 +60,8 @@ gotestsum --no-summary=skipped,output \
    --packages="$formatted_packages" \
    --format=short-verbose \
    --rerun-fails=2
-   --format=testname \
-   --rerun-fails=2
 
+# End-to-End
 
 cd op-e2e
 make test-actions

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -8,67 +8,64 @@ forge --version
 
 cd packages/contracts-bedrock
 
-# pwd
+just pre-pr
 
-# just pre-pr
+just test
 
-# just test
+cd ../..
 
-# cd ../..
+make lint-go
 
-# make lint-go
-
-# make build
+make build
 
 # # Build other essential components
-# cd op-program && make op-program-client && cd ..
-# cd cannon && make elf && cd ..
-# cd op-e2e && make pre-test && cd ..
+cd op-program && make op-program-client && cd ..
+cd cannon && make elf && cd ..
+cd op-e2e && make pre-test && cd ..
 
-# export ENABLE_KURTOSIS=true
-# export OP_E2E_CANNON_ENABLED="false"
-# export OP_E2E_SKIP_SLOW_TEST=true
-# export OP_E2E_USE_HTTP=true
-# export ENABLE_ANVIL=true
+export ENABLE_KURTOSIS=true
+export OP_E2E_CANNON_ENABLED="false"
+export OP_E2E_SKIP_SLOW_TEST=true
+export OP_E2E_USE_HTTP=true
+export ENABLE_ANVIL=true
 
 # # Set your own RPC URLs below.
-# export SEPOLIA_RPC_URL=<YOUR_SEPOLIA_RPC_URL>
-# export MAINNET_RPC_URL=<YOUR_MAINNET_RPC_URL>
+export SEPOLIA_RPC_URL=<YOUR_SEPOLIA_RPC_URL>
+export MAINNET_RPC_URL=<YOUR_MAINNET_RPC_URL>
+
+packages=(
+    op-batcher
+    op-chain-ops
+    op-node
+    op-proposer
+    op-challenger
+    op-dispute-mon
+    op-conductor
+    op-program
+    op-service
+    op-supervisor
+    op-deployer
+    op-e2e/system
+    op-e2e/e2eutils
+    op-e2e/opgeth
+    op-e2e/interop
+    op-e2e/actions
+    op-e2e/faultproofs
+    packages/contracts-bedrock/scripts/checks
+)
+formatted_packages=""
+for package in "${packages[@]}"; do
+    formatted_packages="$formatted_packages ./$package/..."
+done
+
+gotestsum --no-summary=skipped,output \
+   --packages="$formatted_packages" \
+   --format=short-verbose \
+   --rerun-fails=2
+   --format=testname \
+   --rerun-fails=2
 
 
-#             packages=(
-#                 op-batcher
-#                 op-chain-ops
-#                 op-node
-#                 op-proposer
-#                 op-challenger
-#                 op-dispute-mon
-#                 op-conductor
-#                 op-program
-#                 op-service
-#                 op-supervisor
-#                 op-deployer
-#                 op-e2e/system
-#                 op-e2e/e2eutils
-#                 op-e2e/opgeth
-#                 op-e2e/interop
-#                 op-e2e/actions
-#                 op-e2e/faultproofs
-#                 packages/contracts-bedrock/scripts/checks
-#             )
-#             formatted_packages=""
-#             for package in "${packages[@]}"; do
-#               formatted_packages="$formatted_packages ./$package/..."
-#             done
-
-# gotestsum --no-summary=skipped,output \
-#    --packages="$formatted_packages" \
-#    --format=short-verbose \
-#    --rerun-fails=2
-#    --format=testname \
-#    --rerun-fails=2
-
-
-# cd op-e2e
-# make test-actions
-# make test-ws
+cd op-e2e
+make test-actions
+make test-ws

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -29,10 +29,6 @@ export OP_E2E_SKIP_SLOW_TEST=true
 export OP_E2E_USE_HTTP=true
 export ENABLE_ANVIL=true
 
-# # Set your own RPC URLs below.
-export SEPOLIA_RPC_URL=<YOUR_SEPOLIA_RPC_URL>
-export MAINNET_RPC_URL=<YOUR_MAINNET_RPC_URL>
-
 packages=(
     op-batcher
     op-chain-ops

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -e
+
+#MISE description="Developers' local tests"
+#MISE alias="dt"
+
+forge --version
+
+cd packages/contracts-bedrock
+
+# pwd
+
+# just pre-pr
+
+# just test
+
+# cd ../..
+
+# make lint-go
+
+# make build
+
+# # Build other essential components
+# cd op-program && make op-program-client && cd ..
+# cd cannon && make elf && cd ..
+# cd op-e2e && make pre-test && cd ..
+
+# export ENABLE_KURTOSIS=true
+# export OP_E2E_CANNON_ENABLED="false"
+# export OP_E2E_SKIP_SLOW_TEST=true
+# export OP_E2E_USE_HTTP=true
+# export ENABLE_ANVIL=true
+
+# # Set your own RPC URLs below.
+# export SEPOLIA_RPC_URL=<YOUR_SEPOLIA_RPC_URL>
+# export MAINNET_RPC_URL=<YOUR_MAINNET_RPC_URL>
+
+
+#             packages=(
+#                 op-batcher
+#                 op-chain-ops
+#                 op-node
+#                 op-proposer
+#                 op-challenger
+#                 op-dispute-mon
+#                 op-conductor
+#                 op-program
+#                 op-service
+#                 op-supervisor
+#                 op-deployer
+#                 op-e2e/system
+#                 op-e2e/e2eutils
+#                 op-e2e/opgeth
+#                 op-e2e/interop
+#                 op-e2e/actions
+#                 op-e2e/faultproofs
+#                 packages/contracts-bedrock/scripts/checks
+#             )
+#             formatted_packages=""
+#             for package in "${packages[@]}"; do
+#               formatted_packages="$formatted_packages ./$package/..."
+#             done
+
+# gotestsum --no-summary=skipped,output \
+#    --packages="$formatted_packages" \
+#    --format=short-verbose \
+#    --rerun-fails=2
+#    --format=testname \
+#    --rerun-fails=2
+
+
+# cd op-e2e
+# make test-actions
+# make test-ws

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -23,6 +23,8 @@ cd op-program && make op-program-client && cd ..
 cd cannon && make elf && cd ..
 cd op-e2e && make pre-test && cd ..
 
+make devnet-allocs
+
 export ENABLE_KURTOSIS=true
 export OP_E2E_CANNON_ENABLED="false"
 export OP_E2E_SKIP_SLOW_TEST=true


### PR DESCRIPTION

After installing `mise`, you can run local tests with the following:

```bash
# Set your own RPC URLs below. 
export SEPOLIA_RPC_URL=<YOUR_SEPOLIA_RPC_URL>
export MAINNET_RPC_URL=<YOUR_MAINNET_RPC_URL>
mise run dt
```