### PR TITLE
fix blob index

### DIFF
--- a/op-node/rollup/derive/blob_data_source.go
+++ b/op-node/rollup/derive/blob_data_source.go
@@ -73,6 +73,25 @@ func (ds *BlobDataSource) Next(ctx context.Context) (eth.Data, error) {
 	return data, nil
 }
 
+// getTxSucceedMap returns a map indicating whether tx status is successful if useInboxContract;
+// if !useInboxContract, nil map is returned to indicate that no status check is needed.
+func getTxSucceedMap(ctx context.Context, useInboxContract bool, fetcher L1Fetcher, hash common.Hash) (txSucceeded map[common.Hash]bool, err error) {
+	if !useInboxContract {
+		return
+	}
+	_, receipts, err := fetcher.FetchReceipts(ctx, hash)
+	if err != nil {
+		return nil, NewTemporaryError(fmt.Errorf("failed to fetch L1 block info and receipts: %w", err))
+	}
+	txSucceeded = make(map[common.Hash]bool)
+	for _, receipt := range receipts {
+		if receipt.Status == types.ReceiptStatusSuccessful {
+			txSucceeded[receipt.TxHash] = true
+		}
+	}
+	return
+}
+
 // getTxSucceed returns all successful txs
 func getTxSucceed(ctx context.Context, useInboxContract bool, fetcher L1Fetcher, hash common.Hash, txs types.Transactions) (successTxs types.Transactions, err error) {
 	if !useInboxContract {
@@ -111,12 +130,12 @@ func (ds *BlobDataSource) open(ctx context.Context) ([]blobOrCalldata, error) {
 		}
 		return nil, NewTemporaryError(fmt.Errorf("failed to open blob data source: %w", err))
 	}
-	txs, err = getTxSucceed(ctx, ds.dsCfg.useInboxContract, ds.fetcher, ds.ref.Hash, txs)
+	txSucceedMap, err := getTxSucceedMap(ctx, ds.dsCfg.useInboxContract, ds.fetcher, ds.ref.Hash)
 	if err != nil {
 		return nil, err
 	}
 
-	data, hashes := dataAndHashesFromTxs(txs, &ds.dsCfg, ds.batcherAddr, ds.log)
+	data, hashes := dataAndHashesFromTxs(txs, &ds.dsCfg, ds.batcherAddr, ds.log, txSucceedMap)
 
 	if len(hashes) == 0 {
 		// there are no blobs to fetch so we can return immediately
@@ -145,13 +164,14 @@ func (ds *BlobDataSource) open(ctx context.Context) ([]blobOrCalldata, error) {
 // dataAndHashesFromTxs extracts calldata and datahashes from the input transactions and returns them. It
 // creates a placeholder blobOrCalldata element for each returned blob hash that must be populated
 // by fillBlobPointers after blob bodies are retrieved.
-func dataAndHashesFromTxs(txs types.Transactions, config *DataSourceConfig, batcherAddr common.Address, logger log.Logger) ([]blobOrCalldata, []eth.IndexedBlobHash) {
+func dataAndHashesFromTxs(txs types.Transactions, config *DataSourceConfig, batcherAddr common.Address, logger log.Logger, txSucceedMap map[common.Hash]bool) ([]blobOrCalldata, []eth.IndexedBlobHash) {
 	data := []blobOrCalldata{}
 	var hashes []eth.IndexedBlobHash
 	blobIndex := 0 // index of each blob in the block's blob sidecar
 	for _, tx := range txs {
 		// skip any non-batcher transactions or failed transactions
-		if !(isValidBatchTx(tx, config.l1Signer, config.batchInboxAddress, batcherAddr, logger)) {
+		// blobIndex needs to be incremented for both invalid batch tx and failed tx
+		if (!isValidBatchTx(tx, config.l1Signer, config.batchInboxAddress, batcherAddr, logger)) || (txSucceedMap != nil && !txSucceedMap[tx.Hash()]) {
 			blobIndex += len(tx.BlobHashes())
 			continue
 		}

--- a/op-node/rollup/derive/blob_data_source.go
+++ b/op-node/rollup/derive/blob_data_source.go
@@ -171,6 +171,7 @@ func dataAndHashesFromTxs(txs types.Transactions, config *DataSourceConfig, batc
 	for _, tx := range txs {
 		// skip any non-batcher transactions or failed transactions
 		// blobIndex needs to be incremented for both invalid batch tx and failed tx
+		// if txSucceedMap is nil, it means no status check is needed.
 		if (!isValidBatchTx(tx, config.l1Signer, config.batchInboxAddress, batcherAddr, logger)) || (txSucceedMap != nil && !txSucceedMap[tx.Hash()]) {
 			blobIndex += len(tx.BlobHashes())
 			continue

--- a/op-node/rollup/derive/blob_data_source_test.go
+++ b/op-node/rollup/derive/blob_data_source_test.go
@@ -45,7 +45,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	}
 	calldataTx, _ := types.SignNewTx(privateKey, signer, txData)
 	txs := types.Transactions{calldataTx}
-	data, blobHashes := dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
+	data, blobHashes := dataAndHashesFromTxs(txs, &config, batcherAddr, logger, nil)
 	require.Equal(t, 1, len(data))
 	require.Equal(t, 0, len(blobHashes))
 
@@ -60,14 +60,14 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	}
 	blobTx, _ := types.SignNewTx(privateKey, signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger, nil)
 	require.Equal(t, 1, len(data))
 	require.Equal(t, 1, len(blobHashes))
 	require.Nil(t, data[0].calldata)
 
 	// try again with both the blob & calldata transactions and make sure both are picked up
 	txs = types.Transactions{blobTx, calldataTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger, nil)
 	require.Equal(t, 2, len(data))
 	require.Equal(t, 1, len(blobHashes))
 	require.NotNil(t, data[1].calldata)
@@ -75,7 +75,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	// make sure blob tx to the batch inbox is ignored if not signed by the batcher
 	blobTx, _ = types.SignNewTx(testutils.RandomKey(), signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger, nil)
 	require.Equal(t, 0, len(data))
 	require.Equal(t, 0, len(blobHashes))
 
@@ -84,7 +84,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	blobTxData.To = testutils.RandomAddress(rng)
 	blobTx, _ = types.SignNewTx(privateKey, signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, logger, nil)
 	require.Equal(t, 0, len(data))
 	require.Equal(t, 0, len(blobHashes))
 }

--- a/op-node/rollup/derive/blob_data_source_test.go
+++ b/op-node/rollup/derive/blob_data_source_test.go
@@ -89,6 +89,44 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	require.Equal(t, 0, len(blobHashes))
 }
 
+func TestBlockWithFailedBlobTx(t *testing.T) {
+	// test setup
+	rng := rand.New(rand.NewSource(12345))
+	privateKey := testutils.InsecureRandomKey(rng)
+	publicKey, _ := privateKey.Public().(*ecdsa.PublicKey)
+	batcherAddr := crypto.PubkeyToAddress(*publicKey)
+	batchInboxAddr := testutils.RandomAddress(rng)
+	logger := testlog.Logger(t, log.LvlInfo)
+
+	chainId := new(big.Int).SetUint64(rng.Uint64())
+	signer := types.NewCancunSigner(chainId)
+	config := DataSourceConfig{
+		l1Signer:          signer,
+		batchInboxAddress: batchInboxAddr,
+	}
+
+	// create two valid blob batcher txs
+	var txs types.Transactions
+	for i := 0; i < 2; i++ {
+		blobHash := testutils.RandomHash(rng)
+		blobTxData := &types.BlobTx{
+			Nonce:      rng.Uint64(),
+			Gas:        2_000_000,
+			To:         batchInboxAddr,
+			Data:       testutils.RandomData(rng, rng.Intn(1000)),
+			BlobHashes: []common.Hash{blobHash},
+		}
+		blobTx, _ := types.SignNewTx(privateKey, signer, blobTxData)
+		txs = append(txs, blobTx)
+	}
+
+	// mark the first blob tx as failed
+	txSucceedMap := map[common.Hash]bool{txs[1].Hash(): true}
+	_, blobHashes := dataAndHashesFromTxs(txs, &config, batcherAddr, logger, txSucceedMap)
+	// check the returned blob index is 1
+	require.True(t, len(blobHashes) == 1 && blobHashes[0].Index == 1)
+}
+
 func TestFillBlobPointers(t *testing.T) {
 	blob := eth.Blob{}
 	rng := rand.New(rand.NewSource(1234))


### PR DESCRIPTION
Fixes https://github.com/ethstorage/optimism/issues/165 

The `symptom` is: if there's a failed blob tx before the batch blob tx, the calculated blob index will be wrong.
The reason is that originally we filter all failed transactions before scanning for batch transactions, thus the blob index will be wrong if this case happens. Fixed by combining the `filtering` and `scanning` into a single process and ensure blob index is incremented correctly for each blob tx.