### PR TITLE
fix `make verify-beta-testnet`

### DIFF
--- a/op-program/verify/beta-testnet/cmd/beta-testnet.go
+++ b/op-program/verify/beta-testnet/cmd/beta-testnet.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	// Apply the custom configs by running op-program
-	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "beta testnet", 3335, false)
+	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "3335", 3335, false)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to create runner: %v\n", err.Error())
 		os.Exit(1)


### PR DESCRIPTION
Before this fix, `make verify-beta-testnet` will fail with:

```
CRIT [01-21|15:08:51.931] Application failed                       err="invalid network: \"beta testnet\""
```