### PR TITLE
Improve the mise script

### DIFF
--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -16,6 +16,7 @@ just semgrep-test
 # Solidity
 
 cd packages/contracts-bedrock
+just lint-check
 just pre-pr
 just test
 

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -7,7 +7,7 @@ set -e
 # Just for environment test
 forge --version
 
-# Runs semgrep tests on the entire monorepo.
+# Runs semgrep tests on the entire monorepo
 
 just semgrep
 just semgrep-test

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+SECONDS=0
 
 #MISE description="Developers' local tests"
 #MISE alias="dt"
@@ -76,3 +77,5 @@ gotestsum --no-summary=skipped,output \
 cd op-e2e
 make test-actions
 make test-ws
+
+echo "Execution time: $((SECONDS / 60)) minute(s) and $((SECONDS % 60)) second(s)"

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
-set -e
-SECONDS=0
 
 #MISE description="Developers' local tests"
 #MISE alias="dt"
+
+set -e
+SECONDS=0
+
+error_handler() {
+    echo "Execution time: ${SECONDS} seconds"
+    exit 1
+}
+
+trap 'error_handler' ERR
 
 # Just for environment test
 forge --version

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -13,8 +13,24 @@ error_handler() {
 
 trap 'error_handler' ERR
 
-# Just for environment test
+# Environment tests
+
 forge --version
+
+for var in SEPOLIA_RPC_URL MAINNET_RPC_URL; do
+    if [ -z "${!var}" ]; then
+        echo "Error: $var is not set."
+        exit 1
+    fi
+done
+
+STATUS=$(kurtosis engine status)
+if echo "$STATUS" | grep -q "1.4.3"; then
+    echo "Kurtosis engine is running."
+else
+    echo "The Kurtosis engine is not running, or there is a version mismatch."
+    exit 1
+fi
 
 # Runs semgrep tests on the entire monorepo
 

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -7,6 +7,11 @@ set -e
 # Just for environment test
 forge --version
 
+# Runs semgrep tests on the entire monorepo.
+
+just semgrep
+just semgrep-test
+
 # Solidity
 
 cd packages/contracts-bedrock

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -81,10 +81,4 @@ gotestsum --no-summary=skipped,output \
    --format=short-verbose \
    --rerun-fails=2
 
-# End-to-End
-
-cd op-e2e
-make test-actions
-make test-ws
-
 echo "Execution time: $((SECONDS / 60)) minute(s) and $((SECONDS % 60)) second(s)"

--- a/.mise-tasks/dev-test.sh
+++ b/.mise-tasks/dev-test.sh
@@ -48,7 +48,7 @@ just test
 
 cd ../..
 make lint-go
-make build
+make build-go
 
 cd op-program && make op-program-client && cd ..
 cd cannon && make elf && cd ..


### PR DESCRIPTION
Add `semgrep` tests for code static analysis. These tests were missing in local tests compared to CircleCI's main workflow.

Additionally, put the lint check early before solidity building. This step helps identify common format errors and can be completed quickly.

Other changes:
- environment check like RPC and kurtosis
- remove duplicated e2e tests; already included in go tests
- time metering