### PR TITLE
CircleCI: fix semgrep-scan-local/UpgradeAnchorStateRegistry.s.sol

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
@@ -11,8 +11,7 @@ import {DeployUtils} from "scripts/libraries/DeployUtils.sol";
 // Libraries
 import {GameType, Hash, OutputRoot} from "src/dispute/lib/Types.sol";
 // Contracts
-import {StorageSetter} from "src/universal/StorageSetter.sol";
-
+import {IStorageSetter} from "interfaces/universal/IStorageSetter.sol";
 // Interfaces
 import {IAnchorStateRegistry} from "interfaces/dispute/IAnchorStateRegistry.sol";
 import {IDisputeGameFactory} from "interfaces/dispute/IDisputeGameFactory.sol";
@@ -79,7 +78,9 @@ contract UpgradeAnchorStateRegistry is Script {
         if (_storageSetter == address(0)) {
             _storageSetter = DeployUtils.create1({
                 _name: "StorageSetter",
-                _args: DeployUtils.encodeConstructor("")
+                _args: DeployUtils.encodeConstructor(
+                    abi.encodeCall(IStorageSetter.__constructor__, ())
+                )
             });
         }
 

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
@@ -73,13 +73,13 @@ contract UpgradeAnchorStateRegistry is Script {
     ) internal {
         address anchorStateRegistryImpl = DeployUtils.create1({
             _name: "AnchorStateRegistry",
-            _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (_disputeGameFactoryProxy)))
+            _args: DeployUtils.encodeConstructor(abi.encodeCall(IAnchorStateRegistry.__constructor__, (_disputeGameFactoryProxy)))
         });
 
         if (_storageSetter == address(0)) {
             _storageSetter = DeployUtils.create1({
                 _name: "StorageSetter",
-                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, ()))
+                _args: DeployUtils.encodeConstructor("")
             });
         }
 

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
@@ -112,9 +112,8 @@ contract UpgradeAnchorStateRegistry is Script {
     {
         return
             abi.encodeCall(
-                bytes4(keccak256("setBytes32(bytes32,bytes32)")),
-                0,
-                0
+                StorageSetter.setBytes32(bytes32, bytes32),
+                (bytes32(0), bytes32(0))
             );
     }
 

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
@@ -73,13 +73,13 @@ contract UpgradeAnchorStateRegistry is Script {
     ) internal {
         address anchorStateRegistryImpl = DeployUtils.create1({
             _name: "AnchorStateRegistry",
-            _args: abi.encode(_disputeGameFactoryProxy)
+            _args: DeployUtils.encodeConstructor(_disputeGameFactoryProxy)
         });
 
         if (_storageSetter == address(0)) {
             _storageSetter = DeployUtils.create1({
                 _name: "StorageSetter",
-                _args: ""
+                _args: DeployUtils.encodeConstructor("")
             });
         }
 
@@ -111,7 +111,7 @@ contract UpgradeAnchorStateRegistry is Script {
         returns (bytes memory)
     {
         return
-            abi.encodeWithSelector(
+            abi.encodeCall(
                 bytes4(keccak256("setBytes32(bytes32,bytes32)")),
                 0,
                 0
@@ -136,7 +136,7 @@ contract UpgradeAnchorStateRegistry is Script {
             })
         });
         return
-            abi.encodeWithSelector(
+            abi.encodeCall(
                 IAnchorStateRegistry.initialize.selector,
                 startingAnchorRoots,
                 _superchainConfig
@@ -181,17 +181,17 @@ contract UpgradeAnchorStateRegistry is Script {
         );
     }
 
-    function bytes32ToHex(bytes32 data) internal pure returns (string memory) {
+    function bytes32ToHex(bytes32 _data) internal pure returns (string memory) {
         bytes memory result = new bytes(64);
         for (uint256 i = 0; i < 32; i++) {
-            uint8 byteValue = uint8(data[i]);
+            uint8 byteValue = uint8(_data[i]);
             result[i * 2] = toHexChar(byteValue / 16);
             result[i * 2 + 1] = toHexChar(byteValue % 16);
         }
         return string(result);
     }
 
-    function toHexChar(uint8 b) internal pure returns (bytes1) {
-        return b < 10 ? bytes1(b + 0x30) : bytes1(b + 0x57);
+    function toHexChar(uint8 _b) internal pure returns (bytes1) {
+        return _b < 10 ? bytes1(_b + 0x30) : bytes1(_b + 0x57);
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
@@ -111,11 +111,7 @@ contract UpgradeAnchorStateRegistry is Script {
         pure
         returns (bytes memory)
     {
-        return
-            abi.encodeCall(
-                StorageSetter.setBytes32(bytes32, bytes32),
-                (bytes32(0), bytes32(0))
-            );
+        return abi.encodeCall(IStorageSetter.setBytes32, (0, 0));
     }
 
     function encodeAnchorStateRegistryInitializer(

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
@@ -73,13 +73,13 @@ contract UpgradeAnchorStateRegistry is Script {
     ) internal {
         address anchorStateRegistryImpl = DeployUtils.create1({
             _name: "AnchorStateRegistry",
-            _args: DeployUtils.encodeConstructor(_disputeGameFactoryProxy)
+            _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (_disputeGameFactoryProxy)))
         });
 
         if (_storageSetter == address(0)) {
             _storageSetter = DeployUtils.create1({
                 _name: "StorageSetter",
-                _args: DeployUtils.encodeConstructor("")
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, ()))
             });
         }
 

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
@@ -136,9 +136,8 @@ contract UpgradeAnchorStateRegistry is Script {
         });
         return
             abi.encodeCall(
-                IAnchorStateRegistry.initialize.selector,
-                startingAnchorRoots,
-                _superchainConfig
+                IAnchorStateRegistry.initialize,
+                (startingAnchorRoots, _superchainConfig)
             );
     }
 


### PR DESCRIPTION
The error log can be found [here](https://app.circleci.com/pipelines/circleci/VJoJbnHRXJiFR13mWFvRfZ/SHyYDZiLFYMtveJSZVFKbw/114/workflows/2066e9ed-b23a-451a-bcbb-fe217a7bb00f/jobs/1819/parallel-runs/0/steps/0-103).


The fixes are based on the following `semgrep` rules:
>1.  _args parameter should be wrapped with DeployUtils.encodeConstructor
>2. Use abi.encodeCall instead of abi.encodeWithSelector
>3. Named inputs to functions must be prepended with an underscore


Fast command to reproduce the issue and verify the fix:
```bash
just semgrep
```

The reason why the errors are not detected early in the local environment is that the tests were missing from the `mise` script. Fixed in [this PR](https://github.com/ethstorage/optimism/pull/170).