### PR TITLE
UpgradeSoulGasToken.s.sol: get impl correctly

### DIFF
--- a/packages/contracts-bedrock/interfaces/L2/ISoulGasToken.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ISoulGasToken.sol
@@ -10,4 +10,5 @@ interface ISoulGasToken {
 
     function name() external view returns (string memory);
     function symbol() external view returns (string memory);
+    function owner() external view returns (address);
 }

--- a/packages/contracts-bedrock/interfaces/L2/ISoulGasToken.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ISoulGasToken.sol
@@ -11,4 +11,5 @@ interface ISoulGasToken {
     function name() external view returns (string memory);
     function symbol() external view returns (string memory);
     function owner() external view returns (address);
+    function admin() external view returns (address);
 }

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
@@ -18,11 +18,19 @@ import {ISoulGasToken} from "interfaces/L2/ISoulGasToken.sol";
 
 /// @title UpgradeSoulGasToken
 contract UpgradeSoulGasToken is Script {
+    IProxyAdmin constant proxyAdmin =
+        IProxyAdmin(0x4200000000000000000000000000000000000018);
+    ISoulGasToken constant soulGasToken =
+        ISoulGasToken(0x4200000000000000000000000000000000000800);
+
     function run(address _storageSetter) public {
+        address sgtOwner = getSGTOwner();
+        preCheck();
+
         vm.startBroadcast();
         upgradeSoulGasTokenImpl(_storageSetter);
         vm.stopBroadcast();
-        checkOutput();
+        postCheck(sgtOwner);
     }
 
     function upgradeSoulGasTokenImpl(address _storageSetter) internal {
@@ -35,21 +43,15 @@ contract UpgradeSoulGasToken is Script {
             });
         }
 
-        IProxyAdmin proxyAdmin = IProxyAdmin(
-            0x4200000000000000000000000000000000000018
-        );
-        address payable soulGasToken = payable(
-            0x4200000000000000000000000000000000000800
-        );
         address sgtOwner = ISoulGasToken(soulGasToken).owner();
 
-        address impl = proxyAdmin.getProxyImplementation(soulGasToken);
+        address impl = proxyAdmin.getProxyImplementation(address(soulGasToken));
 
         bytes memory data;
         data = encodeStorageSetterZeroOutInitializedSlot();
-        upgradeAndCall(proxyAdmin, soulGasToken, _storageSetter, data);
+        upgradeAndCall(proxyAdmin, address(soulGasToken), _storageSetter, data);
         data = encodeSoulGasTokenInitializer(sgtOwner);
-        upgradeAndCall(proxyAdmin, soulGasToken, impl, data);
+        upgradeAndCall(proxyAdmin, address(soulGasToken), impl, data);
     }
 
     function encodeStorageSetterZeroOutInitializedSlot()
@@ -89,11 +91,16 @@ contract UpgradeSoulGasToken is Script {
         );
     }
 
-    function checkOutput() public view {
-        ISoulGasToken soulGasToken = ISoulGasToken(
-            0x4200000000000000000000000000000000000800
-        );
+    function getSGTOwner() public view returns (address) {
+        return soulGasToken.owner();
+    }
 
+    function preCheck() public view {
+        address sgtAdmin = soulGasToken.admin();
+        require(sgtAdmin == address(proxyAdmin));
+    }
+
+    function postCheck(address _sgtOwner) public view {
         require(
             keccak256(abi.encodePacked(soulGasToken.name())) ==
                 keccak256("SoulQKC")
@@ -102,5 +109,6 @@ contract UpgradeSoulGasToken is Script {
             keccak256(abi.encodePacked(soulGasToken.symbol())) ==
                 keccak256("SoulQKC")
         );
+        require(soulGasToken.owner() == _sgtOwner);
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
@@ -41,13 +41,14 @@ contract UpgradeSoulGasToken is Script {
         address payable soulGasToken = payable(
             0x4200000000000000000000000000000000000800
         );
+        address sgtOwner = ISoulGasToken(soulGasToken).owner();
 
         address impl = proxyAdmin.getProxyImplementation(soulGasToken);
 
         bytes memory data;
         data = encodeStorageSetterZeroOutInitializedSlot();
         upgradeAndCall(proxyAdmin, soulGasToken, _storageSetter, data);
-        data = encodeSoulGasTokenInitializer();
+        data = encodeSoulGasTokenInitializer(sgtOwner);
         upgradeAndCall(proxyAdmin, soulGasToken, impl, data);
     }
 
@@ -59,16 +60,13 @@ contract UpgradeSoulGasToken is Script {
         return abi.encodeCall(IStorageSetter.setBytes32, (0, 0));
     }
 
-    function encodeSoulGasTokenInitializer()
-        internal
-        view
-        virtual
-        returns (bytes memory)
-    {
+    function encodeSoulGasTokenInitializer(
+        address _sgtOwner
+    ) internal view virtual returns (bytes memory) {
         return
             abi.encodeCall(
                 ISoulGasToken.initialize,
-                ("SoulQKC", "SoulQKC", tx.origin)
+                ("SoulQKC", "SoulQKC", _sgtOwner)
             );
     }
 

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
@@ -42,7 +42,7 @@ contract UpgradeSoulGasToken is Script {
             0x4200000000000000000000000000000000000800
         );
 
-        address impl = IProxy(soulGasToken).implementation();
+        address impl = proxyAdmin.getProxyImplementation(soulGasToken);
 
         bytes memory data;
         data = encodeStorageSetterZeroOutInitializedSlot();


### PR DESCRIPTION
The [`Proxy.implementation()`](https://github.com/ethereum-optimism/optimism/blob/969382a3ff0fb577a7fda6287f3c74f8c26dce53/packages/contracts-bedrock/src/universal/Proxy.sol#L98) method can only be called from ProxyAdmin, otherwise will revert since there's no such method in the implementation contract.

**UPDATE**

This PR also ensures that sgt owner is not changed during the upgrade with 1f2f2c9f8df4c7025dcdd1ca42de052c9b05bf5c.