### PR TITLE
UpgradeSoulGasToken.s.sol: get admin correctly

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
@@ -80,9 +80,7 @@ contract UpgradeSoulGasToken is Script {
     }
 
     function preCheck() public view {
-        address sgtAdmin = proxyAdmin.getProxyAdmin(
-            payable(address(soulGasToken))
-        );
+        address sgtAdmin = proxyAdmin.getProxyAdmin(payable(address(soulGasToken)));
         require(sgtAdmin == address(proxyAdmin));
     }
 

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
@@ -96,7 +96,9 @@ contract UpgradeSoulGasToken is Script {
     }
 
     function preCheck() public view {
-        address sgtAdmin = soulGasToken.admin();
+        address sgtAdmin = proxyAdmin.getProxyAdmin(
+            payable(address(soulGasToken))
+        );
         require(sgtAdmin == address(proxyAdmin));
     }
 


### PR DESCRIPTION
The `soulGasToken.admin()` call in the `preCheck` will revert for similar reason as https://github.com/ethstorage/optimism/pull/173, this PR fixes it.

Lessons learned are that we need to call `IProxyAdmin` methods to call `Proxy` methods, otherwise it'll be dispatched to the implementation contract.

(Note the patched `UpgradeSoulGasToken.s.sol` has already been applied successfully on beta testnet, so that this PR serves more as knowledge sharing.)